### PR TITLE
fix(storage): correct k8s-2 OSD device paths and disable auto-purge

### DIFF
--- a/kubernetes/apps/storage/rook-ceph-cluster/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/rook-ceph-cluster/app/helmrelease.yaml
@@ -135,7 +135,9 @@ spec:
           limits:
             cpu: 2000m
             memory: 6Gi
-      removeOSDsIfOutAndSafeToRemove: true
+      # WHY: 3-node cluster with osd.3 already down — auto-purge on a k8s-2
+      # outage could cascade into purging osd.1. Manual removal only.
+      removeOSDsIfOutAndSafeToRemove: false
       storage:
         useAllNodes: false
         useAllDevices: false
@@ -156,13 +158,12 @@ spec:
               # nvme2n1 is system disk (500GB)
           - name: k8s-2
             devices:
-              - name: /dev/nvme1n1  # 1TB WD_BLACK SN7100
+              - name: /dev/nvme0n1  # 1TB WD_BLACK SN7100 (osd.1)
                 config:
                   deviceClass: nvme
-              - name: /dev/nvme2n1  # 1TB WD_BLACK SN7100
-                config:
-                  deviceClass: nvme
-              # nvme0n1 is system disk (500GB)
+              # nvme1n1 is system disk (Crucial 500GB, XFS STATE on p5)
+              # nvme2n1 would be the 2nd WD SN7100 — currently not enumerated
+              #   (osd.3 down). Re-add this entry if/when the drive returns.
           - name: k8s-3
             devices:
               - name: /dev/nvme0n1  # 1TB WD_BLACK SN7100


### PR DESCRIPTION
## Summary

- Correct k8s-2 device list in `rook-ceph-cluster` HelmRelease: the OSD device is `/dev/nvme0n1` (WD SN7100 backing osd.1), not `/dev/nvme1n1` + `/dev/nvme2n1`. The old config listed the Crucial 500GB OS disk (`nvme1n1`) as an OSD device, which would be a landmine on any future OSD recreate.
- Flip `removeOSDsIfOutAndSafeToRemove` from `true` to `false`. With `osd.3` already down on k8s-2, a prolonged outage of k8s-2 under the old setting could cascade-purge the healthy `osd.1`. On a 3-node cluster, OSD removal should be manual.

## Context

Drafted during an onsite hardware recovery session for the missing WD_BLACK SN7100 that previously backed `osd.3` on k8s-2. This PR is **Phase 0** of the recovery procedure — it must land and be Flux-reconciled before any hardware work on k8s-2 begins, because it protects the surviving `osd.1` during the node shutdowns in Phases 2 and 3.

Ceph is currently `HEALTH_OK` at 5/6 OSDs. `k8s-1` and `k8s-3` device lists are intentionally untouched to keep the blast radius of this PR minimal.

## Test plan

- [ ] CI / kubeconform passes
- [ ] Merge and watch Flux reconcile the `rook-ceph-cluster` Kustomization cleanly
- [ ] Verify no OSD churn: `osd.1` stays `up`, cluster stays `HEALTH_OK` at 5/6
- [ ] Only then proceed to Phase 1 (set `noout`, cordon k8s-2)