### PR TITLE
fix(bootstrap): move CRD filter out of helmfile postRenderer for helm 4 compat

### DIFF
--- a/bootstrap/helmfile.d/00-crds.yaml
+++ b/bootstrap/helmfile.d/00-crds.yaml
@@ -7,10 +7,6 @@ helmDefaults:
   args:
     - --include-crds
     - --no-hooks
-  postRenderer: bash
-  postRendererArgs:
-    - -c
-    - yq eval-all --exit-status 'select(.kind == "CustomResourceDefinition")'
 
 releases:
   - name: cloudflare-dns

--- a/scripts/bootstrap-apps.sh
+++ b/scripts/bootstrap-apps.sh
@@ -94,7 +94,9 @@ function apply_crds() {
         log fatal "File does not exist" "file" "${helmfile_file}"
     fi
 
-    if ! crds=$(helmfile --file "${helmfile_file}" template --quiet) || [[ -z "${crds}" ]]; then
+    if ! crds=$(helmfile --file "${helmfile_file}" template --quiet \
+        | yq eval-all --exit-status 'select(.kind == "CustomResourceDefinition")') \
+        || [[ -z "${crds}" ]]; then
         log fatal "Failed to render CRDs from Helmfile" "file" "${helmfile_file}"
     fi
 

--- a/templates/config/bootstrap/helmfile.d/00-crds.yaml.j2
+++ b/templates/config/bootstrap/helmfile.d/00-crds.yaml.j2
@@ -7,10 +7,6 @@ helmDefaults:
   args:
     - --include-crds
     - --no-hooks
-  postRenderer: bash
-  postRendererArgs:
-    - -c
-    - yq eval-all --exit-status 'select(.kind == "CustomResourceDefinition")'
 
 releases:
   - name: cloudflare-dns


### PR DESCRIPTION
## Summary

Helm 4 removed support for arbitrary binaries as `--post-renderer`; it now only accepts plugins of type `postrenderer/v1`. `bootstrap/helmfile.d/00-crds.yaml` used `postRenderer: bash` + `postRendererArgs: [-c, yq eval-all ...]` to filter rendered manifests down to CRDs, which fails on helm 4 with:

\`\`\`
Error: invalid argument \"bash\" for \"--post-renderer\" flag: plugin: {Name:bash Type:postrenderer/v1} not found
\`\`\`

This change moves the yq filter out of helmfile's \`postRenderer\` and into the shell pipeline in \`scripts/bootstrap-apps.sh\`, keeping behavior identical on helm 3 while unblocking #222 (aqua:helm/helm 3.20.2 → 4.1.4).

## Changes

- \`bootstrap/helmfile.d/00-crds.yaml\` — drop \`postRenderer\` / \`postRendererArgs\`
- \`templates/config/bootstrap/helmfile.d/00-crds.yaml.j2\` — same (keeps rendered output in lockstep with the template)
- \`scripts/bootstrap-apps.sh\` — pipe \`helmfile template --quiet\` through \`yq eval-all --exit-status 'select(.kind == \"CustomResourceDefinition\")'\`

## Validation

Three-way test on live OCI charts (cloudflare-dns, envoy-gateway, kube-prometheus-stack) at the versions currently pinned in \`00-crds.yaml\`:

| Flow | helm | CRD count | Result |
|---|---|---|---|
| Current (helmfile postRenderer) | 3.20.2 | 32 | baseline |
| Edited (shell-pipe yq) | 3.20.2 | 32 | identical |
| Edited (shell-pipe yq) | 4.1.4 | 32 | identical |

Helm 4.1.4 was sourced via \`mise exec aqua:helm/helm@4.1.4\`. Both helmfile \`template\` calls succeed; 01-apps.yaml also renders cleanly under helm 4 with no changes required.

## Scope / blast radius

- \`task configure\`, Flux, day-to-day ops: no helm calls — zero impact
- \`task bootstrap:apps\` (cluster-rebuild path): fixed
- Behavior on current helm 3.20.2: byte-identical to pre-change (verified)

## Unverified

- \`helmfile sync\` under helm 4 is not tested — template dry-run only. The \`helm upgrade --install\` path is mostly compatible between helm 3 and helm 4, and \`cleanupOnFail: true\` in \`01-apps.yaml\` is a helmfile field, but the first real exercise will be a future disaster-recovery / rebuild run. Per ADR 0001 bootstrap is disaster-recovery only, so steady-state risk is zero.

## Follow-up

Once this merges, #222 (aqua:helm/helm 3.20.2 → 4.1.4) should be safe to merge.

## Test plan

- [x] helm 3 + new pipeline produces the same 32 CRDs as helm 3 + old postRenderer
- [x] helm 4 + new pipeline produces the same 32 CRDs
- [x] \`helmfile template\` on 01-apps.yaml passes under helm 4
- [ ] \`task configure\` renders cleanly on the source-of-truth workspace (gitignored cluster.yaml/nodes.yaml/cloudflare-tunnel.json not present here)