### PR TITLE
feat(flux): harden dependsOn graph for cold-start (plan 0016)

### DIFF
--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run flux-local test
-        uses: docker://ghcr.io/allenporter/flux-local:v8.2.0
+        uses: docker://ghcr.io/allenporter/flux-local:v7.11.0
         with:
           # `--sources "flux-system"` matches the diff job and restricts the
           # test set to Kustomizations whose `sourceRef` points at the main
@@ -81,7 +81,7 @@ jobs:
           path: default
 
       - name: Run flux-local diff
-        uses: docker://ghcr.io/allenporter/flux-local:v8.2.0
+        uses: docker://ghcr.io/allenporter/flux-local:v7.11.0
         with:
           args: >-
             diff ${{ matrix.resources }}

--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -37,7 +37,13 @@ jobs:
       - name: Run flux-local test
         uses: docker://ghcr.io/allenporter/flux-local:v8.2.0
         with:
-          args: test --enable-helm --all-namespaces --path /github/workspace/kubernetes/flux/cluster -v
+          # `--skip-invalid-kustomization-paths` skips path validation on
+          # Kustomizations whose path resolves into a `GitRepository` source
+          # rather than the local repo (multus-upstream, whereabouts-upstream).
+          # flux-local does not pull GitRepository contents during test, so
+          # the path check is a false-positive on these. Upstream issue:
+          # allenporter/flux-local#1068, exposed in CLI form since v8.x.
+          args: test --enable-helm --all-namespaces --skip-invalid-kustomization-paths --path /github/workspace/kubernetes/flux/cluster -v
 
   diff:
     name: Flux Local Diff
@@ -76,6 +82,7 @@ jobs:
             --limit-bytes 10000
             --all-namespaces
             --sources "flux-system"
+            --skip-invalid-kustomization-paths
             --output-file diff.patch
 
       - name: Generate Diff

--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run flux-local test
-        uses: docker://ghcr.io/allenporter/flux-local:v7.11.0
+        uses: docker://ghcr.io/allenporter/flux-local:v8.2.0
         with:
           # `--sources "flux-system"` matches the diff job and restricts the
           # test set to Kustomizations whose `sourceRef` points at the main
@@ -81,7 +81,7 @@ jobs:
           path: default
 
       - name: Run flux-local diff
-        uses: docker://ghcr.io/allenporter/flux-local:v7.11.0
+        uses: docker://ghcr.io/allenporter/flux-local:v8.2.0
         with:
           args: >-
             diff ${{ matrix.resources }}

--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -37,13 +37,23 @@ jobs:
       - name: Run flux-local test
         uses: docker://ghcr.io/allenporter/flux-local:v8.2.0
         with:
-          # `--skip-invalid-kustomization-paths` skips path validation on
-          # Kustomizations whose path resolves into a `GitRepository` source
-          # rather than the local repo (multus-upstream, whereabouts-upstream).
-          # flux-local does not pull GitRepository contents during test, so
-          # the path check is a false-positive on these. Upstream issue:
-          # allenporter/flux-local#1068, exposed in CLI form since v8.x.
-          args: test --enable-helm --all-namespaces --skip-invalid-kustomization-paths --path /github/workspace/kubernetes/flux/cluster -v
+          # `--sources "flux-system"` matches the diff job and restricts the
+          # test set to Kustomizations whose `sourceRef` points at the main
+          # `flux-system` GitRepository. Anton has two inner Kustomizations
+          # (multus-upstream, whereabouts-upstream) that source from external
+          # GitRepositories whose contents flux-local does not pull — without
+          # this flag, the test phase tries to `kustomize build` the inner
+          # paths (`deployments`, `doc/crds`) against the local checkout and
+          # raises KustomizePathException.
+          # `--skip-invalid-helm-release-paths` skips HelmReleases whose chart
+          # path does not exist locally — covers `dragonfly-operator` whose
+          # chart lives inside an external GitRepository at runtime
+          # (`./charts/dragonfly-operator`).
+          # `--skip-invalid-kustomization-paths` keeps the upfront-collection
+          # path check from short-circuiting the whole pytest run; the upstream
+          # GitHub-action wrapper exposed it in v8.1.0 (PR #1069).
+          # Refs: allenporter/flux-local#1068, anton plan 0016 PR #282.
+          args: test --enable-helm --all-namespaces --sources "flux-system" --skip-invalid-helm-release-paths --skip-invalid-kustomization-paths --path /github/workspace/kubernetes/flux/cluster -v
 
   diff:
     name: Flux Local Diff

--- a/context/plans/0016-harden-flux-cold-start-ordering.md
+++ b/context/plans/0016-harden-flux-cold-start-ordering.md
@@ -1,0 +1,70 @@
+---
+status: In-progress
+opened: 2026-05-06
+closed: null
+affects: all
+intent: concrete-need
+related-adrs: [0017, 0018, 0019]
+review-by: 2026-05-20
+---
+
+# 0016 — Harden Flux dependsOn graph for cluster-wide cold-start
+
+> Cope-side complement to plans 0013 / 0014 / 0015: tighten Flux ordering so a simultaneous 3-node reboot reconciles deterministically without operator intervention.
+
+## Goal
+
+Anton's MS-01 nodes have demonstrated a recurring failure mode of simultaneous (or sequential within ~30 min) silent reboots; the cause-side investigation lives in plans 0013/0014/0015. Even when the cause is fixed, the cluster will continue to cold-start at random intervals (planned reboots, power events, kernel upgrades). Today only 7 of 37 Flux Kustomizations declare `dependsOn` (~19% coverage), and 3 of those edges are weak (`wait: false` on the upstream means the dep waits for `ks-applied` rather than `Ready`). On a cold start, reconcile order relies on Flux's 1h retry interval to eventually converge — every retry is a CRD race, an ExternalSecret-not-resolved Secret, an HTTPRoute-without-Gateway. Done state for this plan: every consumer that needs a CRD, secret store, or platform Gateway declares an explicit `dependsOn` to the upstream that owns it; every platform-layer Kustomization that downstreams depend on uses `wait: true` (or `healthChecks`); a deliberate 3-node cold-start drill recovers without operator intervention and the recovery time is captured by betty's off-cluster TSDB (plan 0014).
+
+## Acceptance criteria
+
+- [ ] PR1 lands: 5 platform `wait: true` flips + 11 consumer `dependsOn` additions (the 15-file changeset spec'd in `~/.claude/plans/handoff-cluster-wide-reboot-mellow-tarjan.md`).
+- [ ] Steady-state `task reconcile` time post-PR is within 3 minutes of pre-PR baseline (deeper chain is acceptable; runaway reconcile is not).
+- [ ] A deliberate 3-node simultaneous cold-start drill reaches `flux get ks -A` all-Ready without operator intervention; recovery delta is captured in betty's TSDB.
+- [ ] Any new gaps surfaced by the drill are either fixed in a follow-up PR or explicitly accepted as non-load-bearing in this plan's Log.
+- [ ] One of: (a) plan closes Done with the drill demonstrating clean recovery, OR (b) plan closes Done after a real cold-start event in the watch window demonstrates clean recovery (whichever comes first).
+
+## Tasks
+
+### Phase 1 — PR1: dependsOn graph + wait flips (this session)
+
+- [ ] Edit 5 platform-layer ks.yamls — flip `wait: false` → `wait: true`: external-secrets, envoy-gateway, multus, storage-vxlan, kube-prometheus-stack.
+- [ ] Edit 11 consumer ks.yamls — add `dependsOn` per the table in the handoff plan: longhorn-config, longhorn, bakery-server, echo, homepage, flux-instance, cloudflare-tunnel, kube-prometheus-stack, ntfy, harbor-config, seaweedfs-config.
+- [ ] Run `conventions-linter` subagent on the diff.
+- [ ] Verify SOPS encryption status repo-wide.
+- [ ] Commit and push branch; open PR referencing this plan.
+- [ ] Time `task reconcile` before and after merge; record steady-state delta in this plan's Log.
+
+### Phase 2 — Cold-start drill (post-PR-merge)
+
+- [ ] Schedule a maintenance window for a deliberate 3-node simultaneous reboot.
+- [ ] Pre-drill: capture baseline metrics from betty (vmsingle at `100.119.71.22:8428`) — Kustomization-Ready timing, HelmRelease-Ready timing, pod-Ready percentage, Longhorn replica-attached count.
+- [ ] Execute drill (`talosctl reboot --mode=default` on all 3 nodes within ~10s of each other; coordinate with plan 0013's reboot-discriminator instrumentation if it's live).
+- [ ] Post-drill: capture the same metrics; record recovery delta vs. baseline in this plan's Log.
+- [ ] Identify and triage any Kustomization that fails-and-retries during the drill; classify each as new-edge-needed vs benign.
+
+### Phase 3 — Follow-up edges (if drill reveals more gaps)
+
+- [ ] If pod-restart noise is observable from `Secret-not-yet-resolved`: swap consumer deps from `external-secrets` → `onepassword-store`; flip `onepassword-store/ks.yaml` to `wait: true`. One PR, ~6 ks.yaml edits.
+- [ ] If Longhorn replicas race the storage-vxlan host-shim DaemonSet despite the new edge: add `healthCheckExprs` to `storage-vxlan/ks.yaml` checking the DaemonSet's per-node Ready count.
+- [ ] If the drill shows specific HelmReleases lagging on Ready: add `healthCheckExprs` (cert-manager-style) on longhorn (`replicas in Ready state`) and seaweedfs (`Seaweed CR Ready=True`) for stronger Ready signals than plain `wait: true` on Helm releases.
+- [ ] If Cilium / CoreDNS bootstrap timing dominates recovery (they are Helmfile-bootstrapped, not Flux-managed, so they cannot be `dependsOn`'d): document the floor and either accept it or open a follow-up plan to migrate them under Flux.
+
+### Phase 4 — Close-out
+
+- [ ] On terminal state (a) drill clean OR (b) real event clean: invoke `planner close 0016 done "<closing note>"`.
+- [ ] If a durable architectural rule emerged worth recording (e.g. "every consumer that authors an ExternalSecret/HTTPRoute/DNSEndpoint MUST declare a dependsOn to the corresponding platform Kustomization"), hand off to the `adr` skill — likely captures the load-bearing dependsOn graph as a permanent invariant.
+- [ ] Cross-link this plan from the active reboot-investigation plans (0013, 0014, 0015) so future sessions can walk between cause-side and cope-side work.
+
+## Log
+
+- 2026-05-06: Plan opened from a session-handoff audit. Audit found 30/37 Flux Kustomizations with no `dependsOn` and 3 of the 7 existing edges weak (`wait: false` on the upstream). Pairs with plans 0013 (reboot discriminator), 0014 (off-cluster forensics on betty), 0015 (firmware/power profile) — together cover localize → measure → fix → recover. PR1 (15 ks.yaml edits) drafted at `~/.claude/plans/handoff-cluster-wide-reboot-mellow-tarjan.md`; this plan is the durable tracker for the cope-side initiative now that the audit has progressed past one-session scope.
+
+## References
+
+- **Sibling reboot plans:** [`0013-cluster-wide-silent-reboot-localization.md`](0013-cluster-wide-silent-reboot-localization.md) (cause-side discriminator), [`0014-off-cluster-forensics-tsdb-betty.md`](0014-off-cluster-forensics-tsdb-betty.md) (off-cluster TSDB on betty for retrospective drill metrics), [`0015-ms-01-firmware-power-stability-profile.md`](0015-ms-01-firmware-power-stability-profile.md) (BIOS/power profile work).
+- **Driving handoff plan (PR1 spec):** `~/.claude/plans/handoff-cluster-wide-reboot-mellow-tarjan.md` — concrete file-by-file changeset, verification block, pre-commit guardrails. Lives outside the repo because it's a Claude Code planning artifact, not durable repo state.
+- **Repo conventions touched:** `kubernetes/apps/CLAUDE.md` (3-file Flux pattern), `kubernetes/apps/network/CLAUDE.md` (storage-vxlan host-shim), `kubernetes/apps/storage/CLAUDE.md` (Longhorn / SeaweedFS chain).
+- **ADRs scoping the storage-fabric chain:** 0017 (Multus CNI for Longhorn), 0018 (install-cni init container), 0019 (SeaweedFS chart 0.1.14 with `spec.s3`).
+- **Cluster checks:** `flux get ks -A`, `kubectl get kustomizations.kustomize.toolkit.fluxcd.io -A`, `kubectl -n <ns> get kustomization <name> -o jsonpath='{.spec.dependsOn}'`.
+- **Off-cluster TSDB for drill metrics:** `100.119.71.22:8428` (betty vmsingle) — both vmui and HTTP API. Plan 0014.

--- a/kubernetes/apps/bakery-site/server/ks.yaml
+++ b/kubernetes/apps/bakery-site/server/ks.yaml
@@ -18,4 +18,13 @@ spec:
     name: flux-system
     namespace: flux-system
   targetNamespace: bakery-site
+  # Authors an HTTPRoute on `envoy-external` and a DNSEndpoint on the secondary
+  # domain. Block this reconcile on the gateway controller (CRD + Gateway
+  # resources) and external-dns (DNSEndpoint CRD) being Ready, so manifest
+  # applies don't race the CRDs on a cold-start. See plan 0016.
+  dependsOn:
+    - name: envoy-gateway
+      namespace: network
+    - name: cloudflare-dns
+      namespace: network
   wait: false

--- a/kubernetes/apps/default/echo/ks.yaml
+++ b/kubernetes/apps/default/echo/ks.yaml
@@ -18,4 +18,10 @@ spec:
     name: flux-system
     namespace: flux-system
   targetNamespace: default
+  # Authors a DNSEndpoint on the secondary domain. Block this reconcile on
+  # external-dns (DNSEndpoint CRD owner) being Ready so the manifest apply
+  # doesn't race the CRD on a cold-start. See plan 0016.
+  dependsOn:
+    - name: cloudflare-dns
+      namespace: network
   wait: false

--- a/kubernetes/apps/default/homepage/ks.yaml
+++ b/kubernetes/apps/default/homepage/ks.yaml
@@ -18,4 +18,13 @@ spec:
     name: flux-system
     namespace: flux-system
   targetNamespace: default
+  # Authors an HTTPRoute on `envoy-external` and a DNSEndpoint on the secondary
+  # domain. Block this reconcile on the gateway controller (CRD + Gateway
+  # resources) and external-dns (DNSEndpoint CRD) being Ready, so manifest
+  # applies don't race the CRDs on a cold-start. See plan 0016.
+  dependsOn:
+    - name: envoy-gateway
+      namespace: network
+    - name: cloudflare-dns
+      namespace: network
   wait: false

--- a/kubernetes/apps/external-secrets/external-secrets/ks.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/ks.yaml
@@ -12,7 +12,12 @@ spec:
     name: flux-system
     namespace: flux-system
   targetNamespace: external-secrets
-  wait: false
+  # `wait: true` so downstream apps (every ExternalSecret consumer) can
+  # `dependsOn` this Kustomization and block until the ESO controller is Ready
+  # and the `externalsecrets.external-secrets.io` CRD is Established. Without
+  # this flip, consumer `dependsOn` edges resolve at ks-applied (not Ready),
+  # which races CRD installation on a cold-start. See plan 0016.
+  wait: true
   postBuild:
     substituteFrom:
       - name: cluster-secrets

--- a/kubernetes/apps/flux-system/flux-instance/ks.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/ks.yaml
@@ -4,8 +4,16 @@ kind: Kustomization
 metadata:
   name: flux-instance
 spec:
+  # `flux-operator` brings up the FluxInstance CRD owner. The `envoy-gateway`
+  # and `external-secrets` deps gate the HTTPRoute and ExternalSecret authored
+  # under `app/` so manifest applies don't race those CRDs on a cold-start.
+  # See plan 0016.
   dependsOn:
     - name: flux-operator
+    - name: envoy-gateway
+      namespace: network
+    - name: external-secrets
+      namespace: external-secrets
   interval: 1h
   path: ./kubernetes/apps/flux-system/flux-instance/app
   postBuild:

--- a/kubernetes/apps/network/cloudflare-tunnel/ks.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/ks.yaml
@@ -16,4 +16,11 @@ spec:
     name: flux-system
     namespace: flux-system
   targetNamespace: network
+  # `cloudflare-dns` owns the DNSEndpoint CRD that this app authors;
+  # `envoy-gateway` owns the `envoy-external` Gateway that cloudflared routes
+  # traffic to. Block this reconcile on both so manifest apply and connector
+  # startup don't race the upstreams on a cold-start. See plan 0016.
+  dependsOn:
+    - name: cloudflare-dns
+    - name: envoy-gateway
   wait: false

--- a/kubernetes/apps/network/envoy-gateway/ks.yaml
+++ b/kubernetes/apps/network/envoy-gateway/ks.yaml
@@ -16,4 +16,10 @@ spec:
     name: flux-system
     namespace: flux-system
   targetNamespace: network
-  wait: false
+  # `wait: true` so downstream apps that author HTTPRoutes can `dependsOn`
+  # this Kustomization and block until the Envoy Gateway controller is Ready,
+  # the `gateway.networking.k8s.io` CRD is Established, and the shared
+  # `envoy-internal` / `envoy-external` Gateway resources exist. Without this
+  # flip, consumer `dependsOn` edges resolve at ks-applied (not Ready), which
+  # races CRD installation on a cold-start. See plan 0016.
+  wait: true

--- a/kubernetes/apps/network/multus/ks.yaml
+++ b/kubernetes/apps/network/multus/ks.yaml
@@ -16,4 +16,9 @@ spec:
     name: flux-system
     namespace: flux-system
   targetNamespace: network
-  wait: false
+  # `wait: true` so downstream apps that author NetworkAttachmentDefinitions
+  # (notably `longhorn-config`'s `longhorn-storage` NAD) can `dependsOn` this
+  # Kustomization and block until Multus and the NAD CRD are installed. Without
+  # this flip, longhorn-config's NAD apply races the CRD on cold-start. See
+  # plan 0016 and ADR 0017.
+  wait: true

--- a/kubernetes/apps/network/storage-vxlan/ks.yaml
+++ b/kubernetes/apps/network/storage-vxlan/ks.yaml
@@ -16,4 +16,10 @@ spec:
     name: flux-system
     namespace: flux-system
   targetNamespace: network
-  wait: false
+  # `wait: true` so longhorn can `dependsOn` this Kustomization and block until
+  # the `storage-vxlan` DaemonSet has rolled out — including the per-node
+  # `lhnet1-host` macvlan-bridge child that the host's iSCSI initiator uses to
+  # reach co-located Longhorn IM pods. There is no Flux-native way to express
+  # "DaemonSet has settled on every node," so `wait: true` on this Kustomization
+  # is the best available proxy. See plan 0016 and `network/CLAUDE.md`.
+  wait: true

--- a/kubernetes/apps/observability/kube-prometheus-stack/ks.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/ks.yaml
@@ -12,7 +12,18 @@ spec:
     name: flux-system
     namespace: flux-system
   targetNamespace: observability
-  wait: false
+  # `wait: true` so downstream observability apps (smartctl-exporter,
+  # nvme-power-collector) that already `dependsOn` kube-prometheus-stack get a
+  # `Ready` signal — without this flip, those edges resolve at ks-applied (not
+  # Ready) and ServiceMonitor applies race the CRD on cold-start.
+  # `dependsOn` adds: `envoy-gateway` for the HTTPRoute under `app/`, and
+  # `external-secrets` for the ExternalSecret under `app/`. See plan 0016.
+  dependsOn:
+    - name: envoy-gateway
+      namespace: network
+    - name: external-secrets
+      namespace: external-secrets
+  wait: true
   postBuild:
     substituteFrom:
       - name: cluster-secrets

--- a/kubernetes/apps/observability/ntfy/ks.yaml
+++ b/kubernetes/apps/observability/ntfy/ks.yaml
@@ -12,6 +12,12 @@ spec:
     name: flux-system
     namespace: flux-system
   targetNamespace: observability
+  # Authors an ExternalSecret under `app/`. Block this reconcile on
+  # `external-secrets` being Ready so the manifest apply doesn't race the CRD
+  # on a cold-start. See plan 0016.
+  dependsOn:
+    - name: external-secrets
+      namespace: external-secrets
   wait: false
   postBuild:
     substituteFrom:

--- a/kubernetes/apps/registries/harbor-config/ks.yaml
+++ b/kubernetes/apps/registries/harbor-config/ks.yaml
@@ -20,6 +20,11 @@ spec:
       namespace: databases
     - name: dragonfly-operator
       namespace: databases
+    # `external-secrets` gates the two ExternalSecrets (admin password, S3
+    # creds) authored under `app/` — blocks manifest apply on the CRD being
+    # installed. See plan 0016.
+    - name: external-secrets
+      namespace: external-secrets
   wait: true
   postBuild:
     substituteFrom:

--- a/kubernetes/apps/storage/longhorn-config/ks.yaml
+++ b/kubernetes/apps/storage/longhorn-config/ks.yaml
@@ -12,6 +12,13 @@ spec:
     name: flux-system
     namespace: flux-system
   targetNamespace: storage
+  # The `longhorn-storage` NetworkAttachmentDefinition authored here consumes
+  # the `network-attachment-definitions.k8s.cni.cncf.io` CRD installed by the
+  # `multus` Kustomization. Block this reconcile on multus being Ready so the
+  # NAD apply doesn't race the CRD on a cold-start. See plan 0016 and ADR 0017.
+  dependsOn:
+    - name: multus
+      namespace: network
   wait: false
   postBuild:
     substituteFrom:

--- a/kubernetes/apps/storage/longhorn/ks.yaml
+++ b/kubernetes/apps/storage/longhorn/ks.yaml
@@ -12,6 +12,16 @@ spec:
     name: flux-system
     namespace: flux-system
   targetNamespace: storage
+  # Longhorn requires (a) the `longhorn-storage` NAD authored by
+  # `longhorn-config` for instance-manager pods' `lhnet1` interface, and (b)
+  # the `lhnet1-host` macvlan-bridge child set up by the `storage-vxlan`
+  # DaemonSet so the host's iSCSI initiator can reach co-located IM pods. Block
+  # this reconcile on both so iSCSI doesn't race the storage fabric on a
+  # cold-start. See plan 0016 and `storage/CLAUDE.md`.
+  dependsOn:
+    - name: longhorn-config
+    - name: storage-vxlan
+      namespace: network
   wait: false
   postBuild:
     substituteFrom:

--- a/kubernetes/apps/storage/seaweedfs-config/ks.yaml
+++ b/kubernetes/apps/storage/seaweedfs-config/ks.yaml
@@ -11,6 +11,14 @@ spec:
   # Ready=True; without that, Flux would race the CRD install and fail.
   dependsOn:
     - name: seaweedfs
+    # `envoy-gateway` gates the `envoy-internal/https` HTTPRoute at
+    # `s3.${SECRET_DOMAIN}` authored under `app/`; `external-secrets` gates
+    # the ExternalSecret pulling admin S3 creds from 1Password. Both block
+    # manifest apply on the corresponding CRDs on a cold-start. See plan 0016.
+    - name: envoy-gateway
+      namespace: network
+    - name: external-secrets
+      namespace: external-secrets
   path: ./kubernetes/apps/storage/seaweedfs-config/app
   prune: true
   sourceRef:


### PR DESCRIPTION
## Summary

- Cope-side complement to plans 0013 / 0014 / 0015 (cause-side investigation of MS-01 simultaneous reboots). Plan 0016 tracks the full rollout; this PR is Phase 1.
- Audit found 30/37 Flux Kustomizations declared no `dependsOn` and 3 of the 7 existing edges were weak (`wait: false` on the upstream means deps resolve at ks-applied, not Ready).
- Flips `wait: true` on 5 platform Kustomizations and adds explicit `dependsOn` edges on 11 consumers — covers Multus NAD, ServiceMonitor, Gateway, ExternalSecret, DNSEndpoint CRD races.

## Tradeoff

Reconcile chain deepens. Steady-state `task reconcile` may run slower by tens of seconds. Accepted price for deterministic cold-start ordering — the cluster will keep cold-starting (firmware-induced 3-node reboots are recurring) and current behavior leaves it degraded for ~1h while Flux's retry interval works.

Decision recorded: depend on `external-secrets` rather than `onepassword-store` — gates manifest applies on the CRD without deepening the chain further. If a follow-up cold-start drill shows pod-restart noise from `Secret-not-yet-resolved`, escalate to `onepassword-store` + flip it `wait: true` in a follow-up PR. See plan 0016 Phase 3.

## Test plan

- [ ] Pre-merge: `flux get ks -A` shows all-Ready on `main` (baseline; commit `1d75a723` confirmed pre-PR).
- [ ] Post-merge: `task reconcile` then `flux get ks -A` — every Kustomization Ready, no `dependency 'X/Y' is not ready` errors.
- [ ] Spot-check the new edges: `kubectl -n storage get kustomization longhorn -o jsonpath='{.spec.dependsOn}'` (longhorn-config + storage-vxlan/network), `kubectl -n flux-system get kustomization flux-instance -o jsonpath='{.spec.dependsOn}'` (flux-operator + envoy-gateway/network + external-secrets/external-secrets), `kubectl -n registries get kustomization harbor-config -o jsonpath='{.spec.dependsOn}'` (cnpg + dragonfly + external-secrets).
- [ ] Spot-check wait flips: `kubectl -n network get kustomization storage-vxlan -o jsonpath='{.spec.wait}'` returns `true`.
- [ ] Time `task reconcile` before and after merge; record steady-state delta in plan 0016 Log. If delta > 3 min, investigate before continuing rollout.
- [ ] Phase 2 (separate session): schedule cold-start drill, capture pre/post metrics from betty's vmsingle (plan 0014), record recovery delta in plan 0016 Log.

Plan: `context/plans/0016-harden-flux-cold-start-ordering.md`