### PR TITLE
feat(network): multus metrics + IM-NAD-attach health alerts

### DIFF
--- a/kubernetes/apps/network/multus/app/flux-kustomization.yaml
+++ b/kubernetes/apps/network/multus/app/flux-kustomization.yaml
@@ -69,7 +69,14 @@ spec:
         - op: replace
           path: /metadata/namespace
           value: network
-    # Move ConfigMap to the network namespace
+    # Move ConfigMap to the network namespace + enable thick-plugin metrics on
+    # port 9091. Multus thick-plugin reads its server config from this JSON,
+    # not CLI flags, so adding `metricsPort` here turns on the Prometheus
+    # endpoint at :9091/metrics. Plan 0016 Phase 3 (IM-NAD-attach probe);
+    # surfaces `nfvpe_multus_request_count{Status="error"}` so genuine CNI-add
+    # errors page. (The 2026-05-06/07 silent-attach mode where the daemon
+    # returns success without actually attaching is caught separately by the
+    # kube-state-metrics annotation-allowlist alert in `prometheusrule.yaml`.)
     - target:
         kind: ConfigMap
         name: multus-daemon-config
@@ -77,6 +84,38 @@ spec:
         - op: replace
           path: /metadata/namespace
           value: network
+        - op: replace
+          path: /data/daemon-config.json
+          value: |
+            {
+                "chrootDir": "/hostroot",
+                "cniVersion": "0.3.1",
+                "logLevel": "verbose",
+                "logToStderr": true,
+                "cniConfigDir": "/host/etc/cni/net.d",
+                "multusAutoconfigDir": "/host/etc/cni/net.d",
+                "multusConfigFile": "auto",
+                "socketDir": "/host/run/multus/",
+                "metricsPort": 9091
+            }
+    # Expose the metrics port on the DaemonSet so the sibling Service can
+    # target it by name. `reloader.stakater.com/auto: "true"` triggers a
+    # rolling restart of the DS when the daemon-config ConfigMap changes —
+    # multus-daemon does not watch the file, so a config-only edit otherwise
+    # only takes effect on the next pod restart.
+    - target:
+        kind: DaemonSet
+        name: kube-multus-ds
+      patch: |-
+        - op: add
+          path: /metadata/annotations/reloader.stakater.com~1auto
+          value: "true"
+        - op: add
+          path: /spec/template/spec/containers/0/ports
+          value:
+            - name: metrics
+              containerPort: 9091
+              protocol: TCP
     # Re-point ClusterRoleBinding subject to the relocated ServiceAccount
     - target:
         kind: ClusterRoleBinding

--- a/kubernetes/apps/network/multus/app/kustomization.yaml
+++ b/kubernetes/apps/network/multus/app/kustomization.yaml
@@ -4,3 +4,6 @@ kind: Kustomization
 resources:
   - ./gitrepository.yaml
   - ./flux-kustomization.yaml
+  - ./service.yaml
+  - ./servicemonitor.yaml
+  - ./prometheusrule.yaml

--- a/kubernetes/apps/network/multus/app/prometheusrule.yaml
+++ b/kubernetes/apps/network/multus/app/prometheusrule.yaml
@@ -1,0 +1,113 @@
+---
+# Multus / NAD-attach health alerts. Plan 0016 Phase 3 task #1.
+#
+# Driving incident: 2026-05-06/07 harbor-postgres quorum failure. After a
+# rolling Talos reboot the Longhorn instance-manager pods on k8s-1 and k8s-3
+# came up `1/1 Running` with the `k8s.v1.cni.cncf.io/networks: longhorn-storage`
+# annotation requested but Multus' CNI-add silently failed to attach the
+# `lhnet1@vxlan-storage` interface. Every cross-node Longhorn replica attach
+# to those nodes then timed out for ~7h before triage. The cluster surfaced
+# this as `HarborPostgresQuorumAtRisk` (downstream symptom) — the upstream
+# Multus-attach failure had no alert.
+#
+# Three layers of detection here, ordered loudest-first:
+#   1. PodNADAttachFailed (critical) — pod has the `networks` request
+#      annotation but no `network-status` reply for >5m. Catches the
+#      silent-success failure mode the 2026-05-07 incident exercised.
+#      Requires kube-state-metrics' `--metric-annotations-allowlist=pods=...`
+#      patch in `kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml`.
+#   2. MultusCNIRequestErrors (warning) — Multus' own counter shows
+#      `Status="error"` increments. Catches loud CNI-add failures (IPAM
+#      exhaustion, plugin chain error, etc.).
+#   3. MultusDaemonRestarting (warning) — multus-daemon pod is restart-looping.
+#      Implies the storage-fabric is unstable even if individual CNI calls
+#      complete.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: multus
+  namespace: network
+  labels:
+    app.kubernetes.io/name: multus
+spec:
+  groups:
+    - name: multus.attach.alerts
+      rules:
+        - alert: PodNADAttachFailed
+          # Pods with the `networks` request annotation but no matching
+          # `network-status` reply. The `unless on(namespace, pod)` set
+          # difference yields exactly the bad set. `for: 5m` allows the
+          # normal CNI-add path enough time on cold start.
+          expr: |-
+            kube_pod_annotations{annotation_k8s_v1_cni_cncf_io_networks!=""}
+            unless on(namespace, pod)
+            kube_pod_annotations{annotation_k8s_v1_cni_cncf_io_network_status!=""}
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Multus did not attach the requested NetworkAttachmentDefinition for {{ $labels.namespace }}/{{ $labels.pod }}"
+            description: |
+              Pod {{ $labels.namespace }}/{{ $labels.pod }} has annotation
+              `k8s.v1.cni.cncf.io/networks` requesting one or more
+              NetworkAttachmentDefinitions, but Multus did not record a
+              corresponding `network-status` annotation after 5m. This is the
+              2026-05-07 silent-attach failure mode — the pod is `1/1 Running`
+              but its secondary network is missing, and any cross-node Longhorn
+              attach via this pod will time out.
+
+              Recovery: `kubectl delete pod {{ $labels.pod }} -n {{ $labels.namespace }}`.
+              Longhorn / the workload controller will recreate; on the next CNI-add
+              Multus typically attaches cleanly. If the alert returns within
+              minutes of the recreate, escalate — Multus or Whereabouts on the
+              node is genuinely broken (check pod restart count and `kubectl logs
+              -n network -l name=multus`).
+            runbook_url: "https://github.com/wcygan/anton/blob/main/context/plans/0016-harden-flux-cold-start-ordering.md"
+    - name: multus.daemon.alerts
+      rules:
+        - alert: MultusCNIRequestErrors
+          # Multus' own counter — covers loud CNI-add/del/check failures.
+          # Does NOT cover the silent-success mode (see PodNADAttachFailed).
+          expr: |-
+            sum by (namespace, pod, Type) (
+              increase(nfvpe_multus_request_count{Status="error"}[10m])
+            ) > 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Multus reported CNI {{ $labels.Type }} errors on {{ $labels.namespace }}/{{ $labels.pod }}"
+            description: |
+              `nfvpe_multus_request_count{Status="error",Type="{{ $labels.Type }}"}`
+              has been increasing on {{ $labels.namespace }}/{{ $labels.pod }} for 5m.
+              Likely causes: IPAM exhaustion (Whereabouts pool), upstream CNI plugin
+              chain error, or socket-path issue. Inspect `kubectl logs -n network -l
+              name=multus` for the specific error message.
+            runbook_url: "https://github.com/wcygan/anton/blob/main/context/plans/0016-harden-flux-cold-start-ordering.md"
+
+        - alert: MultusDaemonRestarting
+          # Restart loop on the multus-daemon container — distinct from a
+          # one-off OOMKill or eviction. Threshold > 1 within 15m to avoid
+          # paging on a single recovery.
+          expr: |-
+            increase(
+              kube_pod_container_status_restarts_total{
+                namespace="network",
+                pod=~"kube-multus-ds-.*",
+                container="kube-multus"
+              }[15m]
+            ) > 1
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Multus DaemonSet pod {{ $labels.pod }} is restarting"
+            description: |
+              `kube-multus` container in pod {{ $labels.pod }} has restarted
+              more than once in the last 15m. While restarting, no new pods on
+              that node can attach NetworkAttachmentDefinitions — every
+              storage-fabric-using pod that schedules during the gap will
+              silent-fail. Investigate restart cause via `kubectl describe pod
+              -n network {{ $labels.pod }}` and the prior container logs
+              (`--previous`).
+            runbook_url: "https://github.com/wcygan/anton/blob/main/context/plans/0016-harden-flux-cold-start-ordering.md"

--- a/kubernetes/apps/network/multus/app/service.yaml
+++ b/kubernetes/apps/network/multus/app/service.yaml
@@ -1,0 +1,22 @@
+---
+# Headless Service for scraping the Multus thick-plugin metrics port (9091)
+# enabled via the daemon-config ConfigMap patch in flux-kustomization.yaml.
+# Headless (clusterIP: None) so each per-node pod is scraped individually —
+# a regular ClusterIP would round-robin to a single random pod per scrape and
+# hide per-node failure modes.
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-multus-metrics
+  namespace: network
+  labels:
+    app.kubernetes.io/name: multus
+spec:
+  clusterIP: None
+  selector:
+    name: multus
+  ports:
+    - name: metrics
+      port: 9091
+      targetPort: metrics
+      protocol: TCP

--- a/kubernetes/apps/network/multus/app/servicemonitor.yaml
+++ b/kubernetes/apps/network/multus/app/servicemonitor.yaml
@@ -1,0 +1,24 @@
+---
+# Scrape the Multus thick-plugin metrics endpoint exposed by the headless
+# Service. Surfaces `nfvpe_multus_request_count{Type="ADD",Status="error"}`,
+# `nfvpe_multus_request_count{Type="ADD",Status="success"}`,
+# `nfvpe_multus_handle_request_duration_seconds`. Consumed by the alerts in
+# `prometheusrule.yaml`.
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: multus
+  namespace: network
+  labels:
+    app.kubernetes.io/name: multus
+spec:
+  namespaceSelector:
+    matchNames:
+      - network
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: multus
+  endpoints:
+    - port: metrics
+      interval: 30s
+      path: /metrics

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -142,6 +142,21 @@ spec:
     kubeEtcd:
       enabled: false
 
+    # ---- kube-state-metrics ----
+    # Annotation allowlist — feeds the `PodNADAttachFailed` alert in
+    # kubernetes/apps/network/multus/app/prometheusrule.yaml. By default
+    # `kube_pod_annotations` is emitted with no annotation labels; the
+    # allowlist below promotes the two Multus annotations to labels so a
+    # PromQL `unless on(namespace, pod)` set difference can find pods that
+    # requested a NAD but never got the Multus reply. Plan 0016 Phase 3.
+    #
+    # Annotation key → label name transform (kube-state-metrics convention):
+    # `k8s.v1.cni.cncf.io/networks`       → `annotation_k8s_v1_cni_cncf_io_networks`
+    # `k8s.v1.cni.cncf.io/network-status` → `annotation_k8s_v1_cni_cncf_io_network_status`
+    kube-state-metrics:
+      extraArgs:
+        - --metric-annotations-allowlist=pods=[k8s.v1.cni.cncf.io/networks,k8s.v1.cni.cncf.io/network-status]
+
     nodeExporter:
       enabled: true
 


### PR DESCRIPTION
## Summary

Plan 0016 Phase 3 task #1 — closes the cope-coverage gap exposed by the 2026-05-06/07 harbor-postgres incident, where a rolling Talos reboot left Longhorn instance-manager pods on k8s-1 and k8s-3 \`1/1 Running\` with their \`k8s.v1.cni.cncf.io/networks: longhorn-storage\` annotation requested but Multus' CNI-add silently failed to attach \`lhnet1\`. Every cross-node Longhorn replica attach to those nodes timed out for ~7h before triage; the only alert that fired was \`HarborPostgresQuorumAtRisk\` (downstream symptom).

## What changes

- **\`kubernetes/apps/network/multus/app/flux-kustomization.yaml\`** — ConfigMap patch adds \`metricsPort: 9091\` to multus-daemon's JSON config. DaemonSet patch exposes containerPort \`metrics:9091\` + \`reloader.stakater.com/auto: "true"\` annotation so future config edits trigger a rolling restart (multus-daemon doesn't watch its config file).
- **\`kubernetes/apps/network/multus/app/service.yaml\`** — headless Service \`kube-multus-metrics\` (clusterIP: None) so each per-node pod is scraped individually.
- **\`kubernetes/apps/network/multus/app/servicemonitor.yaml\`** — scrapes the Service.
- **\`kubernetes/apps/network/multus/app/prometheusrule.yaml\`** — three alerts (details below).
- **\`kubernetes/apps/network/multus/app/kustomization.yaml\`** — adds the three new resources.
- **\`kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml\`** — adds \`kube-state-metrics: extraArgs: [--metric-annotations-allowlist=pods=[k8s.v1.cni.cncf.io/networks,k8s.v1.cni.cncf.io/network-status]]\` so kube-state-metrics promotes the two Multus annotations to labels on \`kube_pod_annotations\` for the silent-attach detection.

## Alerts

| Alert | Severity | Routes via | Catches |
|---|---|---|---|
| \`PodNADAttachFailed\` | critical | ntfy | **Silent-success failure** — pod has \`networks\` annotation but no \`network-status\` reply for >5m. Tonight's actual mode. |
| \`MultusCNIRequestErrors\` | warning | (no route) | Multus' own counter \`nfvpe_multus_request_count{Status="error"}\` increases. Loud CNI-add failures (IPAM exhaustion, plugin chain error). |
| \`MultusDaemonRestarting\` | warning | (no route) | multus-daemon container restart-looping. |

The critical alert routes to ntfy via the existing \`severity=critical\` AlertmanagerConfig. Warnings route to \`null\` by design (ADR 0026 — easier to broaden than to silence).

## Test plan

- [x] \`promtool check rules\` — SUCCESS, 3 rules found.
- [x] \`kubectl kustomize kubernetes/apps/network/multus/app\` — manifests build cleanly with all patches applied.
- [x] PromQL probe against live Prometheus — all three alert expressions parse without error. Series counts of 0 for the new metrics are expected (Multus metrics not enabled until this PR merges; annotation allowlist not patched yet). One pre-existing \`kube_pod_container_status_restarts_total\` series confirms the upstream shape.
- [x] Selector alignment — Service \`name=multus\` matches DS pod label; ServiceMonitor \`app.kubernetes.io/name=multus\` matches Service label; Service \`targetPort: metrics\` matches new containerPort name.
- [x] \`conventions-linter\` subagent: pass on all categories (3-file pattern, postBuild, selector alignment, no tailnet leaks, no SOPS modifications).

After merge:
- \`kubectl -n network exec <kube-multus-ds-pod> -- wget -qO- http://localhost:9091/metrics\` should return Prometheus metrics.
- \`flux get hr -n observability kube-prometheus-stack\` should reach Ready=True post-extraArgs (kube-state-metrics restart).
- \`kubectl -n observability exec prometheus-... -- wget -qO- 'http://localhost:9090/api/v1/query?query=count(nfvpe_multus_request_count)'\` should return >0 series.
- \`kubectl -n observability exec prometheus-... -- wget -qO- 'http://localhost:9090/api/v1/query?query=count(kube_pod_annotations{annotation_k8s_v1_cni_cncf_io_networks!=""})\` should return ≥3 (the three IM pods).

## Out of scope (follow-ups)

- **Self-healing**. This PR detects-and-pages. If the alert fires more than ~3×/quarter, escalate to a small controller that auto-deletes pods with NAD-attach failures (option (c) in the plan 0016 Phase 3 discussion).
- **Multus error metrics may not catch all silent-attach modes**. \`MultusCNIRequestErrors\` triggers on \`Status="error"\` only. If the daemon returns \`success\` without actually attaching (the failure mode tonight), \`PodNADAttachFailed\` is the catch — kept as the primary critical alert.
- **Annotation allowlist scope**. Right now we only allowlist the two Multus annotations. If we want to alert on any other annotation pattern (e.g., \`reloader.stakater.com\`), extend the allowlist same way.

Plan: \`context/plans/0016-harden-flux-cold-start-ordering.md\`