### PR TITLE
feat(clickstack): scaffold ADR 0028 logs/traces experiment

### DIFF
--- a/.claude/skills/clickstack-ops/SKILL.md
+++ b/.claude/skills/clickstack-ops/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: clickstack-ops
+description: Operate the time-boxed ClickStack logs/traces experiment on anton (ClickHouse + Keeper + MongoDB + OTel collector + HyperDX, per ADR 0028). Use to access the HyperDX UI, send a test signal (pod logs via the bundled OTel collector, point Temporal's OTLP traces at it), run Lucene/SQL queries, check health of any ClickStack component, reconcile/debug the Flux flow, rotate the 1Password credentials via ESO, triage Renovate bumps for the two operators + chart, run the 2026-08-02 review-by checklist, or execute the exit/teardown runbook. Keywords — clickstack, hyperdx, clickhouse, keeper, mongodb, otel collector, otlp, logs, traces, wide events, lucene, temporal traces, teardown, exit plan, review-by, ADR 0028.
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash
+---
+
+# clickstack-ops
+
+Operational skill for the **ClickStack** learning experiment on anton — ClickHouse (column store) + Keeper + MongoDB + an OpenTelemetry Collector + HyperDX (Lucene/SQL UI for logs and traces). This is a **60-day throwaway eval** per ADR 0028 (`context/adrs/0028-clickstack-learning-experiment.md`), reviewed by **2026-08-02**. The deliverable is a successor ADR to 0008 that confirms or re-ranks the logs/traces backend shortlist. This skill is for running the eval day-to-day, not for production hardening.
+
+Read ADR 0028 for the *why*. This skill assumes you already know the Flux 3-file pattern — if not, load `anton-repo-conventions` or `debug-flux-reconciliation` first.
+
+## Containment rules (ADR 0028 — non-negotiable, don't relax for convenience)
+
+- **Pillar separation is the key rule.** Metrics stay 100% on kube-prometheus-stack. ClickStack owns **only** logs + traces. Do **not** bridge Prometheus metrics into ClickHouse, do **not** add a ServiceMonitor that forks prod metrics, do **not** make anything outside `clickstack` `dependsOn` it.
+- Own `clickstack` namespace only.
+- Evaluate ClickStack **as-shipped** — the chart's bundled ClickHouse + Keeper + MongoDB + OTel collector. Do not externalize to production CNPG / SeaweedFS / etc.
+- HyperDX UI exposed via `envoy-internal` HTTPRoute **only** — no Cloudflare tunnel, no `envoy-external`.
+- Explicit resource limits on ClickHouse; all default passwords overridden via ESO.
+
+## When to invoke
+
+| Intent | Section / Reference |
+| --- | --- |
+| Open the HyperDX UI / first-login | [USAGE](#usage) · [usage](references/usage.md) |
+| Send a test signal — pod logs via the bundled collector | [usage](references/usage.md#test-signal-pod-logs-via-the-otel-collector) |
+| Point Temporal's OTLP traces at ClickStack (ADR 0028 follow-up) | [usage](references/usage.md#test-signal-temporal-otlp-traces) |
+| Run a Lucene or SQL query in HyperDX | [usage](references/usage.md#querying-lucene-and-sql) |
+| Check health of ClickHouse / Keeper / MongoDB / HyperDX / collector | [OPERATIONS](#operations) · [operations](references/operations.md#health-checks) |
+| Reconcile / debug the Flux flow | [operations](references/operations.md#reconcile-and-debug) |
+| Rotate the 1Password credentials (ESO) | [operations](references/operations.md#credential-rotation-eso--1password) |
+| Triage a Renovate bump (two operators + chart) | [MAINTENANCE](#maintenance) · [maintenance](references/maintenance.md#renovate-posture) |
+| Run the 2026-08-02 review-by checklist | [maintenance](references/maintenance.md#review-by-checklist-2026-08-02) |
+| Tear the whole thing down | [maintenance](references/maintenance.md#exit--teardown-runbook) |
+
+## Anton-specific facts (don't re-derive these)
+
+- **Namespace**: `clickstack`. Everything lives here. Namespace prune is disabled.
+- **Two-phase install** (ADR 0028 / ADR 0027):
+  - `clickstack-operators` — Flux Kustomization, `wait: true`. Installs the **ClickHouse Kubernetes Operator** (`ClickHouseCluster` + `KeeperCluster` CRDs — NOT Altinity's `clickhouse-operator`/`ClickHouseInstallation`) and the **MongoDB Community Operator (MCK)** (`MongoDBCommunity` CRD). Chart `clickstack-operators` **1.0.0**.
+  - `clickstack-app` — `dependsOn` operators + `external-secrets` + `envoy-gateway`. Installs HyperDX + OTel collector + the `ClickHouseCluster`/`KeeperCluster`/`MongoDBCommunity` CRs. Chart `clickstack` **3.0.0** (appVersion 2.27.0).
+- **Source**: both charts come from a classic Helm repo (`HelmRepository`), not OCI: `https://clickhouse.github.io/ClickStack-helm-charts`. The operators app's source is named `clickstack`; the main app's is named `clickstack-charts` (distinct names so two Kustomizations in one namespace don't co-own one source object).
+- **HyperDX naming quirk**: release name is `clickstack`, but the chart's `clickstack.hyperdx.fullname` helper appends `-app`, so the HyperDX **Deployment and Service render as `clickstack-app`**. The HTTPRoute backendRef and the `clickstack-app` ks.yaml healthCheck both reference that name. A top-level `fullnameOverride` is deliberately NOT set (it would desync ClickHouse/Keeper/MongoDB names from the release-derived OTel service name).
+- **HyperDX URL**: `https://hyperdx.${SECRET_DOMAIN}` via `envoy-internal`. `${SECRET_DOMAIN}` is substituted by Flux postBuild from the `cluster-secrets` Secret — never hardcode the domain.
+- **OTel collector is Deployment-mode, not DaemonSet.** It receives telemetry via OTLP (`4317` gRPC / `4318` HTTP) and writes to ClickHouse. It does **not** scrape pod logs by default — wiring the filelog receiver is the operational test-signal step (see usage).
+- **Credentials**: ESO `ExternalSecret` `clickstack-credentials` pulls four fields from 1Password vault `anton`, item `clickstack`. Flux injects each into the chart values via `valuesFrom` + `targetPath: hyperdx.secrets.*`. The ESO Secret is deliberately named `clickstack-credentials`, **not** `clickstack-secret` — the chart unconditionally renders its own `clickstack-secret`, so a same-named ESO target would fight Helm over ownership.
+  - **OPEN ITEM**: as of scaffold, the 1Password item `clickstack` does not yet exist. It must be created with fields `HYPERDX_API_KEY`, `CLICKHOUSE_PASSWORD`, `CLICKHOUSE_APP_PASSWORD`, `MONGODB_PASSWORD` before the ExternalSecret resolves. See [operations](references/operations.md#credential-rotation-eso--1password).
+- **Manifests** (source of truth, prefer reading these over re-deriving):
+  - Operators: `kubernetes/apps/clickstack/clickstack-operators/app/helmrelease.yaml`
+  - Main chart values: `kubernetes/apps/clickstack/clickstack-app/app/helmrelease.yaml`
+  - ESO: `kubernetes/apps/clickstack/clickstack-app/app/externalsecret.yaml`
+  - HTTPRoute: `kubernetes/apps/clickstack/clickstack-app/app/httproute.yaml`
+
+## USAGE
+
+Accessing HyperDX, sending a test signal, and querying. Full recipes in [usage](references/usage.md).
+
+- **Access the UI**: `https://hyperdx.${SECRET_DOMAIN}` (envoy-internal, on-LAN or via Tailscale per `anton-remote-access`). First login creates the local HyperDX account; the data source (ClickHouse connection) is seeded by HyperDX itself for the eval (`useExistingConfigSecret: false`).
+- **Test signal — pod logs**: the bundled collector listens for OTLP but does not tail pod logs out of the box. To feed it logs you either (a) add a **filelog receiver** to the collector config, or (b) point an app's OTLP log exporter at the collector Service. Recipe + the in-cluster OTLP endpoint in [usage](references/usage.md#test-signal-pod-logs-via-the-otel-collector).
+- **Test signal — Temporal OTLP traces** (ADR 0028 follow-up, **not** part of the scaffold): point the Temporal server's OTLP trace exporter at the ClickStack collector's gRPC endpoint. **Do not edit the Temporal app manifests as part of this skill's scaffolding** — this is a deliberate, separate operational change. Endpoint + Temporal-side config in [usage](references/usage.md#test-signal-temporal-otlp-traces).
+- **Querying**: HyperDX supports Lucene-style search and a SQL mode against ClickHouse. Patterns for the four ADR 0028 success criteria (cross-pod / ≥24h wide-events questions) in [usage](references/usage.md#querying-lucene-and-sql).
+
+## OPERATIONS
+
+Health, reconcile/debug, and credential rotation. Full recipes in [operations](references/operations.md).
+
+- **Health**: walk operators → CRs → workloads. `flux get hr -n clickstack`, then the `ClickHouseCluster`/`KeeperCluster`/`MongoDBCommunity` CR status, then the HyperDX Deployment, collector, and pods. One-liners in [operations](references/operations.md#health-checks).
+- **Reconcile / debug**: standard anton Flux flow — `flux reconcile ks clickstack-operators -n flux-system` then `clickstack-app`. The two-phase `dependsOn` means a stuck operators phase blocks the app phase; check that first. Hand deep Flux stalls to the `debug-flux-reconciliation` skill / `flux-debugger` subagent.
+- **Credential rotation**: rotate in 1Password item `clickstack`, let ESO refresh (or force it), then restart the consuming pods — ESO/Helm value injection does not hot-reload. Ordered steps in [operations](references/operations.md#credential-rotation-eso--1password). For the broader rotation discipline, see the `rotate-credential` skill.
+
+## MAINTENANCE
+
+Renovate posture, the review-by checklist, and teardown. Full detail in [maintenance](references/maintenance.md).
+
+- **Renovate**: three young pins enter the audit queue — `clickstack-operators` 1.0.0, `clickstack` 3.0.0, and transitively the two bundled operators. Treat operator-major bumps as cluster-tier (CRD churn risk); chart bumps as their own tier. Posture + merge guidance in [maintenance](references/maintenance.md#renovate-posture). Hand PR triage to `anton-upgrade-audit` / `upgrade-auditor`.
+- **Review-by 2026-08-02**: answer ADR 0028's four success criteria with evidence, then either write the ADR 0008 successor (via the `adr` skill) and execute the exit plan, or consciously re-decide. **Do not let the experiment lapse silently** — the review-by field is load-bearing. Checklist in [maintenance](references/maintenance.md#review-by-checklist-2026-08-02).
+- **Exit / teardown**: `flux suspend` → delete the namespace → remove the two operators, their ClusterRoles, and the three CRDs. Eval data is throwaway. Full runbook with the exact resources to remove in [maintenance](references/maintenance.md#exit--teardown-runbook).
+
+## Related skills
+
+- `anton-repo-conventions` — SOPS-vs-ESO, postBuild, Flux-namespace rules
+- `debug-flux-reconciliation` — when the manifest is committed but the HelmRelease / CR hasn't applied
+- `rotate-credential` — the durable rotation procedure ESO credential rotation rides on
+- `anton-upgrade-audit` — Renovate PR triage and tiered merge order for the operator + chart bumps
+- `adr` — author the ADR 0008 successor at the 2026-08-02 review
+- `observability-integrate` — the metrics pillar that ClickStack must **not** touch (read it to know the boundary)
+- `expose-service` — HTTPRoute mechanics (HyperDX is already wired; relevant only if exposure changes)
+
+## Pointers
+
+- ADR 0028 (the experiment, success criteria, exit plan): `context/adrs/0028-clickstack-learning-experiment.md`
+- ADR 0027 (the platform `dependsOn` rule the two phases follow): `context/adrs/0027-platform-dependson-rule.md`
+- ADR 0008 (deferred logs/traces roadmap this eval informs): `context/adrs/0008-*.md`
+- ADR 0007 (metrics-only baseline ClickStack must not displace): `context/adrs/0007-adopt-kube-prometheus-stack.md`

--- a/.claude/skills/clickstack-ops/references/maintenance.md
+++ b/.claude/skills/clickstack-ops/references/maintenance.md
@@ -1,0 +1,93 @@
+# ClickStack — MAINTENANCE
+
+Renovate posture, the 2026-08-02 review-by checklist, and the exit/teardown runbook. This is a throwaway 60-day eval (ADR 0028) — maintenance is about keeping it contained and tearing it down cleanly, not about long-term hardening.
+
+## Renovate posture
+
+Three young pins enter the audit queue for the duration of the eval (ADR 0028 explicitly accepts this rising upgrade tax):
+
+| Artifact | Pinned at | Where |
+| --- | --- | --- |
+| `clickstack-operators` chart | `1.0.0` | `clickstack-operators/app/helmrelease.yaml` |
+| `clickstack` chart | `3.0.0` (appVersion 2.27.0) | `clickstack-app/app/helmrelease.yaml` |
+| ClickHouse operator + MongoDB MCK operator | bundled by the operators chart | (transitive — moves when the operators chart bumps) |
+
+**Rules:**
+
+- **Both charts are pinned to exact versions** (no ranges) — Renovate owns every bump as a discrete PR. Do not introduce ranges.
+- **Treat operators-chart bumps as cluster-tier.** They carry the two operators and can churn the `ClickHouseCluster` / `KeeperCluster` / `MongoDBCommunity` CRDs. CRD/operator-major changes can break the CRs the main chart renders. Read release notes; reconcile in a low-stakes window; verify the CRs still reconcile (see `operations.md` health checks) before considering the PR done.
+- **Treat main-chart (`clickstack`) bumps as their own tier**, after the operators chart is known-good. A `clickstack` major may change HyperDX naming, the `hyperdx.secrets.*` value paths the `valuesFrom` injection depends on, or the OTel collector shape — re-verify the four `valuesFrom`/`targetPath` mappings and the `clickstack-app` Service name after any major.
+- **This is throwaway** — if a bump is disruptive and the eval is near its review-by date, the right move is often to **decline the bump and tear down on schedule**, not to invest in the migration. Weigh upgrade effort against remaining timebox.
+
+Hand actual PR triage and tiered merge ordering to the `anton-upgrade-audit` skill / `upgrade-auditor` subagent; this section is just the ClickStack-specific posture they should apply.
+
+## Review-by checklist (2026-08-02)
+
+ADR 0028's `review-by: 2026-08-02` is **load-bearing** — a learning intake without an enforced review becomes permanent intake. At (or before) that date, produce falsifiable answers to the four success criteria, then decide.
+
+**1. Answer the four success criteria with evidence:**
+
+- [ ] **Criterion 1 — wide-events querying vs VictoriaLogs.** Did ClickHouse-backed querying meaningfully beat VictoriaLogs for cross-pod / ≥24h questions (ADR 0008 Trigger 1)? Cite specific queries you ran (see `usage.md`) and their latency/UX.
+- [ ] **Criterion 2 — "ClickHouse too heavy" at homelab scale.** Record real CPU/RAM/operational cost of ClickHouse + Keeper + MongoDB + HyperDX (`kubectl top pods` over the eval) vs a VictoriaLogs single binary. Is the "too heavy" claim from ADR 0008 still true given ~85 GiB free RAM/node?
+- [ ] **Criterion 3 — HyperDX UX vs Grafana-as-front-door.** Was HyperDX's wide-events UX worth abandoning Grafana, or did running two UIs confirm ADR 0008's fragmentation concern?
+- [ ] **Criterion 4 — containment held.** Did it stay in its namespace and the logs/traces pillar, or did it drift toward a second metrics store? (You should be able to answer "no metrics ever entered ClickHouse.")
+
+**2. Decide and act:**
+
+- [ ] Write the **ADR 0008 successor** via the `adr` skill — either *confirm* the VictoriaLogs+Jaeger shortlist with evidence, or *re-rank* toward a ClickHouse/HyperDX backend. This is the experiment's deliverable.
+- [ ] Then **execute the exit plan** (below) — or **consciously re-decide** to extend, recording that as its own ADR. Do not let the experiment lapse silently.
+
+## Exit / teardown runbook
+
+Per ADR 0028. Eval data is throwaway — no production signal ever depends on it, so no data migration. Removal is heavier than a bundled StatefulSet because of the two operators and cluster-scoped CRDs.
+
+Do each step deliberately; the destructive ones (`delete namespace`, CRD removal) require explicit operator confirmation per the root CLAUDE.md hard rules.
+
+**1. Suspend Flux so it stops re-creating what you delete:**
+
+```sh
+flux suspend ks clickstack-app -n flux-system
+flux suspend ks clickstack-operators -n flux-system
+```
+
+**2. Remove the manifests from Git** (the GitOps-correct teardown — Flux prunes on the next reconcile if not suspended; since we suspended, we delete by hand below). Delete the `kubernetes/apps/clickstack/` tree and its entry in the parent kustomization, commit, push.
+
+**3. Delete the application namespace** (removes HyperDX, OTel collector, ClickHouse/Keeper/MongoDB StatefulSets, PVCs, the ESO Secret, the HTTPRoute, and the CRs):
+
+```sh
+kubectl delete namespace clickstack   # destructive — confirm with operator first
+```
+
+**4. Delete the custom resources first if the namespace delete hangs** — operator finalizers can block namespace deletion. Remove the CRs, then re-try the namespace delete:
+
+```sh
+kubectl -n clickstack delete clickhousecluster --all
+kubectl -n clickstack delete keepercluster --all
+kubectl -n clickstack delete mongodbcommunity --all
+```
+
+**5. Remove the two operators' cluster-scoped leftovers.** Namespace deletion does NOT remove cluster-scoped objects. Find and remove the operators' ClusterRoles / ClusterRoleBindings (names are operator-specific — list before deleting):
+
+```sh
+kubectl get clusterrole,clusterrolebinding | grep -iE 'clickhouse|keeper|mongodb'
+# then delete the ones owned by the ClickHouse operator and MongoDB MCK
+```
+
+**6. Remove the three CRDs** (cluster-scoped — the heaviest part of the exit cost ADR 0028 flagged). This is irreversible for any remaining CRs:
+
+```sh
+kubectl get crd | grep -iE 'clickhouse|keeper|mongodb'
+kubectl delete crd clickhouseclusters.<group>
+kubectl delete crd keeperclusters.<group>
+kubectl delete crd mongodbcommunity.<group>   # resolve exact CRD names from the get above
+```
+
+**7. Tear down the Temporal test signal if you wired it** (`usage.md`): revert the Temporal OTLP exporter change so Temporal isn't pointing at a dead collector. This is a Temporal-app manifest change — separate commit.
+
+**8. Clean up out-of-cluster bits:**
+
+- [ ] Delete the 1Password item `clickstack` from vault `anton` (the four credential fields).
+- [ ] Confirm the `hyperdx.${SECRET_DOMAIN}` DNS/HTTPRoute is gone (deleted with the namespace).
+- [ ] Verify nothing in `flux get ks -A` still references clickstack and no orphan CRDs remain.
+
+**9. Record the teardown** — note it in the ADR 0008 successor (or an exit note), so the removal is in the graveyard for any future re-evaluation (`cluster-intake` checks the graveyard).

--- a/.claude/skills/clickstack-ops/references/operations.md
+++ b/.claude/skills/clickstack-ops/references/operations.md
@@ -1,0 +1,120 @@
+# ClickStack — OPERATIONS
+
+Health checks, reconcile/debug via the anton Flux flow, and credential rotation. All read-first; mutating steps are committed-and-reconciled, not `kubectl apply`. Verify kube context before any mutating command (see root CLAUDE.md).
+
+## Health checks
+
+Walk top-down: Flux releases → operators → custom resources → workloads → pods. The two-phase install means a problem in the operators phase masks everything downstream — check it first.
+
+```sh
+# 1. Flux view — both Kustomizations and both HelmReleases Ready?
+flux get ks -A | grep clickstack
+flux get hr -n clickstack
+
+# 2. Operators present? (ClickHouse operator + MongoDB MCK)
+kubectl -n clickstack get deploy
+kubectl get crd | grep -iE 'clickhouse|keeper|mongodb'
+#   expect: clickhouseclusters / keeperclusters (ClickHouse operator),
+#           mongodbcommunity (MongoDB MCK)
+
+# 3. Custom resources reconciled by the operators
+kubectl -n clickstack get clickhousecluster,keepercluster,mongodbcommunity
+kubectl -n clickstack describe clickhousecluster   # status/conditions on stall
+
+# 4. Workloads
+kubectl -n clickstack get deploy,sts,pods -o wide
+#   clickstack-app  = HyperDX Deployment (the -app suffix is the chart helper)
+#   ClickHouse / Keeper / MongoDB render as StatefulSets
+#   otel collector is a Deployment
+
+# 5. HTTPRoute accepted + backend resolvable
+kubectl -n clickstack get httproute hyperdx -o wide
+
+# 6. ESO Secret materialized (gates the HelmRelease valuesFrom)
+kubectl -n clickstack get externalsecret clickstack-credentials
+kubectl -n clickstack get secret clickstack-credentials
+```
+
+**Per-component sanity:**
+
+```sh
+# ClickHouse responds (resolve the pod/sts name first from step 4)
+kubectl -n clickstack exec <clickhouse-pod> -- clickhouse-client --query "SELECT 1"
+
+# Keeper quorum (single replica for this eval — just confirm it's up)
+kubectl -n clickstack logs <keeper-pod> --tail=50
+
+# MongoDB up (HyperDX stores users/dashboards here)
+kubectl -n clickstack logs <mongodb-pod> -c mongod --tail=50
+
+# HyperDX + collector logs
+kubectl -n clickstack logs deploy/clickstack-app --tail=100
+kubectl -n clickstack logs deploy/<otel-collector> --tail=100
+```
+
+**Resource cost (ADR 0028 success criterion 2 — "is ClickHouse too heavy?"):** record real usage over the eval.
+
+```sh
+kubectl -n clickstack top pods
+```
+
+Compare ClickHouse + Keeper + MongoDB + HyperDX + collector against what a VictoriaLogs single binary would cost. Note it against criterion 2.
+
+## Reconcile and debug
+
+Standard anton Flux flow. Reconcile the operators phase first (the app phase `dependsOn` it):
+
+```sh
+flux reconcile ks clickstack-operators -n flux-system --with-source
+flux reconcile ks clickstack-app -n flux-system
+# or the repo shortcut:
+task reconcile
+```
+
+Debug ladder when something is stuck:
+
+1. **App phase won't start / shows dependency-not-ready** → the operators Kustomization (`wait: true`) hasn't reported Ready. Fix operators first: `flux get hr -n clickstack`, then describe the operators HelmRelease for the failing condition.
+2. **ESO Secret missing** → the app HelmRelease's `valuesFrom` can't resolve, and the `clickstack-app` ks.yaml healthCheck on the `clickstack-credentials` Secret fails. Almost always the 1Password item doesn't exist yet (see open item below) or the `onepassword-connect` ClusterSecretStore is unhealthy. `kubectl -n clickstack describe externalsecret clickstack-credentials`.
+3. **CRs not reconciling** → operator pod is up but the `ClickHouseCluster`/`MongoDBCommunity` shows no status. Check the operator logs and the CR `.status`.
+4. **HelmRelease values rejected** → schema/CRD-shape mismatch (e.g. the MongoDB resources path goes through `spec.statefulSet…`, not a top-level `resources` key — see the helmrelease comments). Check the HelmRelease `describe` for the Helm error.
+
+For deep or repeating Flux stalls, hand off to the `debug-flux-reconciliation` skill or the `flux-debugger` subagent.
+
+## Credential rotation (ESO + 1Password)
+
+Four runtime credentials live in 1Password vault `anton`, item **`clickstack`**, consumed via the `clickstack-credentials` ExternalSecret and injected into the chart by Flux `valuesFrom` → `targetPath: hyperdx.secrets.*`.
+
+**OPEN ITEM — first-time setup:** the 1Password item `clickstack` does not yet exist as of scaffold. Create it (do not invent values; the operator generates strong values out of band) with exactly these fields:
+
+| 1Password field | Purpose |
+| --- | --- |
+| `HYPERDX_API_KEY` | HyperDX app secret / API key |
+| `CLICKHOUSE_PASSWORD` | the `otelcollector` ClickHouse user password |
+| `CLICKHOUSE_APP_PASSWORD` | the `app` ClickHouse user password (HyperDX → ClickHouse) |
+| `MONGODB_PASSWORD` | MongoDB password |
+
+Never write these into a `*.sops.*` file or any committed manifest — they live only in 1Password, surfaced by ESO. Log file paths, never values.
+
+**Rotation procedure:**
+
+1. Update the field(s) in 1Password item `clickstack`.
+2. Force ESO to re-pull (or wait for the 1h `refreshInterval`):
+   ```sh
+   kubectl -n clickstack annotate externalsecret clickstack-credentials \
+     force-sync=$(date +%s) --overwrite
+   kubectl -n clickstack get secret clickstack-credentials -o jsonpath='{.metadata.resourceVersion}'
+   ```
+3. **The chart reads these as Helm values at template time, not live from the Secret** — so a new Secret value does not hot-reload. Trigger Flux to re-render the HelmRelease, then let the pods restart with the new values:
+   ```sh
+   flux reconcile hr clickstack -n clickstack --force
+   ```
+   If components don't pick it up, restart the consumers:
+   ```sh
+   kubectl -n clickstack rollout restart deploy/clickstack-app
+   # ClickHouse/Keeper/MongoDB passwords are operator-managed via the CRs — a
+   # password change there may require the operator to reconcile the CR; check
+   # the operator logs rather than restarting StatefulSets blindly.
+   ```
+4. Verify: HyperDX can still reach ClickHouse (run a query) and the pods are not crash-looping.
+
+For the durable cross-credential rotation discipline (age key, deploy key, 1Password token, Cloudflare token), use the `rotate-credential` skill — this section is ClickStack-specific only.

--- a/.claude/skills/clickstack-ops/references/usage.md
+++ b/.claude/skills/clickstack-ops/references/usage.md
@@ -1,0 +1,76 @@
+# ClickStack — USAGE
+
+Accessing HyperDX, sending a test signal, and querying. See `SKILL.md` for the containment rules these recipes must respect.
+
+## Access the HyperDX UI
+
+HyperDX is exposed on `envoy-internal` only (ADR 0028 — no Cloudflare tunnel):
+
+```
+https://hyperdx.${SECRET_DOMAIN}
+```
+
+`${SECRET_DOMAIN}` is the cluster's internal domain, substituted by Flux from the `cluster-secrets` Secret. Resolve the literal value from your environment, never hardcode it. Off-LAN access goes through Tailscale MagicDNS — see the `anton-remote-access` skill.
+
+First login creates a **local HyperDX account** (HyperDX stores its own users/dashboards in the bundled MongoDB). The ClickHouse data source is seeded by HyperDX itself for this eval — the chart's `deployment.useExistingConfigSecret` is `false`, so we do **not** pre-load `connections.json` / `sources.json`. Confirm a source exists under HyperDX → Team Settings → Sources after first login; if not, add one pointing at the in-cluster ClickHouse Service with the `app` user (password = `CLICKHOUSE_APP_PASSWORD` from 1Password).
+
+If the page does not load, check the HTTPRoute is Accepted and the backend is healthy:
+
+```sh
+kubectl -n clickstack get httproute hyperdx -o wide
+kubectl -n clickstack get deploy clickstack-app
+```
+
+## Test signal — pod logs via the OTel collector
+
+The bundled collector runs in **Deployment mode** and receives OTLP; it does **not** tail pod logs by default. There are two ways to feed it the test signal ADR 0028 calls for (pod logs):
+
+**In-cluster OTLP endpoints** (collector Service in the `clickstack` namespace):
+
+```
+http://<collector-service>.clickstack.svc.cluster.local:4318   # OTLP/HTTP
+<collector-service>.clickstack.svc.cluster.local:4317          # OTLP/gRPC
+```
+
+Resolve the exact Service name (it is release-name-derived) before using it:
+
+```sh
+kubectl -n clickstack get svc | grep -i otel
+```
+
+**Option A — filelog receiver (collector tails node pod logs).** Add a `filelog` receiver + a logs pipeline to the collector config via the chart's `otel-collector` values (in `kubernetes/apps/clickstack/clickstack-app/app/helmrelease.yaml`). This usually requires the collector to run as a DaemonSet with `/var/log/pods` mounted, or to mount that path on the Deployment. Validate the receiver's `include` glob against Talos pod-log paths before committing. This is a values-only change to the existing HelmRelease — commit, push, let Flux reconcile; do not `kubectl apply`.
+
+**Option B — point an app's OTLP log exporter at the collector.** Set the app's `OTEL_EXPORTER_OTLP_ENDPOINT` to the collector endpoint above. Lower-footprint than filelog and closer to how Temporal traces will flow. Good first test: a throwaway debug pod that emits OTLP logs.
+
+After either, confirm logs land in ClickHouse via HyperDX search (below) or by querying ClickHouse directly (see `operations.md`).
+
+## Test signal — Temporal OTLP traces
+
+This is the ADR 0028 operational follow-up: point Temporal's server OTLP trace exporter at the ClickStack collector. **Do NOT edit the Temporal app manifests as part of scaffolding this skill** — this is a deliberate, separately-reviewed change to the Temporal app, made when you actively run the eval.
+
+1. Verify the Temporal server's OTLP config surface (Temporal exports traces via OpenTelemetry; check the Temporal HelmRelease / server config for an OTLP exporter block).
+2. Set the trace exporter OTLP endpoint to the ClickStack collector gRPC endpoint:
+   ```
+   <collector-service>.clickstack.svc.cluster.local:4317
+   ```
+   Use the cluster-internal Service DNS (cross-namespace: Temporal namespace → `clickstack` namespace). No HTTPRoute / external exposure for telemetry ingestion — it stays in-cluster.
+3. Confirm no NetworkPolicy blocks Temporal-namespace → `clickstack`-namespace egress on 4317.
+4. Commit the Temporal-side change, push, reconcile. Then verify traces appear in HyperDX (Traces view).
+
+Keep this change reversible and small — it is part of the throwaway eval, removed at teardown.
+
+## Querying — Lucene and SQL
+
+HyperDX offers two query modes against ClickHouse:
+
+- **Lucene-style search** — the default search bar. Field-scoped terms (`level:error service:temporal`), free text, time-range chips. Fast for "show me everything matching X in the last N hours."
+- **SQL mode** — direct ClickHouse SQL against the events tables. Use for aggregations, joins, and the high-cardinality / wide-events questions ADR 0028's success criteria target.
+
+Aim the queries at producing **falsifiable answers** to ADR 0028's four success criteria:
+
+1. **Cross-pod / ≥24h wide-events** (vs VictoriaLogs) — run a query spanning many pods over ≥24h (e.g. group errors by service+pod over a day) and note latency + UX vs what VictoriaLogs would give.
+2. **"ClickHouse too heavy" at homelab scale** — pair query work with the resource measurements in `operations.md` (CPU/RAM of ClickHouse + Keeper + MongoDB + HyperDX).
+3. **HyperDX UX worth abandoning Grafana** — judge the wide-events UX against the cost of running two front-doors.
+4. **Containment** — confirm you never reached for a Prometheus-metric query inside HyperDX; metrics stay on Grafana.
+
+Record observations against the criteria as you go — they feed the 2026-08-02 review and the ADR 0008 successor.

--- a/context/adrs/0028-clickstack-learning-experiment.md
+++ b/context/adrs/0028-clickstack-learning-experiment.md
@@ -1,0 +1,70 @@
+---
+status: Accepted
+date: 2026-06-03
+deciders: ['@wcygan']
+affects: observability
+intent: learning
+supersedes: []
+superseded-by: null
+retrospective: false
+review-by: 2026-08-02
+---
+
+# 0028 — Run ClickStack as a time-boxed logs/traces backend experiment
+
+> 60-day learning intake: stand up ClickStack (ClickHouse + OTel + HyperDX) in a contained namespace to test whether ADR 0008's logs/traces backend shortlist (VictoriaLogs/Jaeger) should be re-ranked — metrics stay on Prometheus throughout.
+
+## Status
+
+Accepted
+
+## Context
+
+ADR 0007 chose kube-prometheus-stack as a deliberate metrics-only baseline. ADR 0008 is a deferred logs+traces roadmap that already decided the collector layer (OpenTelemetry Collector via otel-operator) and ranked the *backends* — VictoriaLogs (logs) and Jaeger (traces) as frontrunners — while explicitly rejecting the ClickHouse all-in-one shape (SigNoz) on three grounds: "ClickHouse is too heavy," "abandons Grafana-as-front-door," and "two metrics stores is worse than one." ADR 0008's Re-adoption-guidance clause 5 leaves an explicit door open: *"the backend shortlist needs revising before any install → write a successor ADR updating the rankings."*
+
+ClickStack is ClickHouse's productized observability stack: ClickHouse (column store) + OpenTelemetry Collector + HyperDX (Lucene/SQL UI for logs, traces, metrics, session replay). Architecturally it is the same family as the SigNoz that 0008 rejected — but the rejection was for *concrete-need production adoption*, and was reasoned from upstream status that decays. anton is partly a learning cluster, and the honest question "do 0008's rejection grounds still hold at anton's scale?" is itself worth testing empirically rather than assuming.
+
+This decision passed the `cluster-intake` gate as honest **learning** intent: containment gates 1–5 pass, the graveyard is clean (no reverted ClickHouse/observability ADR), and crucially ClickStack *keeps* the one thing ADR 0008 already decided (OTel Collector) and only challenges the two things 0008 left open-but-ranked — the **backend** (ClickHouse vs VictoriaLogs/Jaeger) and the **front-door** (HyperDX vs Grafana). This ADR records the experiment, not a production adoption; it does **not** supersede ADR 0007 or 0008.
+
+## Decision
+
+We will run ClickStack as a contained, time-boxed learning experiment in its own `clickstack` namespace, reviewed by **2026-08-02 (60-day timebox)**. The experiment's deliverable is a successor ADR to 0008 that either **confirms** the VictoriaLogs+Jaeger shortlist with evidence or **re-ranks** toward a ClickHouse/HyperDX backend.
+
+Deployment path is the official ClickHouse-maintained Helm charts (`https://clickhouse.github.io/ClickStack-helm-charts`), a two-phase install — `clickstack-operators` (ClickHouse operator + MongoDB MCK operator + CRDs) as a platform Kustomization, then `clickstack` (HyperDX + OTel collector + the `ClickHouseCluster`/`KeeperCluster`/`MongoDBCommunity` custom resources) as a config Kustomization that `dependsOn` the operators per ADR 0027. Credentials flow from 1Password via ESO into the chart's `clickstack-secret` (`useExistingConfigSecret`); the HyperDX UI is exposed via an `envoy-internal` HTTPRoute only.
+
+**Containment conditions (load-bearing — these keep it learning, not creep):**
+
+- Own `clickstack` namespace; nothing else `dependsOn` it.
+- **Pillar separation is the key rule.** Metrics stay 100% on kube-prometheus-stack, untouched. ClickStack must not replace Prometheus, must not become a second metrics store, and must **not** bridge Prometheus metrics into ClickHouse during the eval (that builds the two-store mess and muddies the result). ClickStack owns only the logs+traces pillar. This matches the dominant real-world pattern — keep Prometheus for alerting metrics, use ClickStack for logs/traces/high-cardinality investigation; crossing into metrics is the rarer, weaker path and the ADR-0007 supersession risk.
+- Fed by a deliberately chosen **test signal** — pod logs via the OTel filelog receiver + Temporal's OTLP traces — not a fork of the production metrics path.
+- All chart default passwords overridden via ESO; explicit resource limits on ClickHouse.
+
+**Success criteria (must produce falsifiable answers for the 0008 successor):**
+
+1. Does ClickHouse-backed wide-events querying meaningfully beat VictoriaLogs for the cross-pod / ≥24h questions ADR 0008 Trigger 1 describes?
+2. Is "ClickHouse is too heavy" still true at homelab scale given ~85 GiB free RAM/node? Measure real CPU/RAM/operational cost of ClickHouse + Keeper + MongoDB + HyperDX vs a VictoriaLogs single binary.
+3. Is HyperDX's wide-events UX worth abandoning Grafana-as-front-door, or does running two UIs confirm 0008's fragmentation concern?
+4. Does it stay contained, or drift toward a second metrics store (the containment test itself)?
+
+**Exit plan:** `flux suspend` + delete the `clickstack` namespace + remove the two operators, their ClusterRoles, and the `ClickHouseCluster`/`KeeperCluster`/`MongoDBCommunity` CRDs. Eval data is throwaway; no production signal ever depends on it.
+
+## Alternatives considered
+
+- **Do nothing / wait for ADR 0008 triggers to fire** — the orthodox path. Rejected only because the intent is honest learning with a declared timebox and exit, which is an accepted path on a partly-learning cluster; the experiment also produces evidence that makes the eventual 0008 successor sharper.
+- **Adopt ClickStack as a concrete-need production stack** — rejected. ADR 0007's triggers haven't fired, it would create a second metrics store / supersede 0007, and metrics+alerting is ClickStack's weakest pillar. Gate 4 (no parallel monitoring stack) fails under concrete-need intent.
+- **Evaluate by bridging Prometheus metrics into ClickHouse (community migration pattern)** — rejected for *this* eval. The bridge is correct when the question is "migrate the whole stack," but anton's question is narrowly "is ClickHouse a better logs/traces backend?" Bridging metrics adds a confounding variable and the two-store cleanup cost.
+
+## Consequences
+
+### Accepted costs
+
+- **Moderate (not trivial) exit cost.** Two operators + cluster-scoped CRDs to clean up (`ClickHouseCluster`, `KeeperCluster`, `MongoDBCommunity`) — heavier than a bundled StatefulSet, but reversible without data migration since the data is throwaway. anton already runs operator+CRD components routinely (CNPG, Dragonfly, Longhorn, SeaweedFS), so the shape is familiar.
+- **Renovate / upgrade tax rises materially** — two new, young (v2.x) operators plus the chart enter the audit queue for the duration.
+- **Two observability front-doors during the eval** — Grafana for metrics, HyperDX for logs/traces. This is intentional and is itself data for success criterion 3.
+- **Discipline obligation.** A learning intake without an enforced review date becomes permanent intake. The `review-by: 2026-08-02` field is load-bearing; at that date either write the 0008 successor and tear down, or consciously re-decide.
+
+## Follow-ups
+
+- [ ] Hand off to `add-flux-app` to scaffold the `clickstack` namespace: operators platform Kustomization (`wait: true`) + `clickstack` config Kustomization (`dependsOn` operators, per ADR 0027) + ESO ExternalSecret → `clickstack-secret` + `envoy-internal` HTTPRoute for HyperDX.
+- [ ] Wire the test signal: OTel filelog receiver for pod logs + Temporal OTLP traces export (verify Temporal server OTLP config).
+- [ ] **2026-08-02 review:** answer the four success criteria, then either write the ADR 0008 successor (confirm or re-rank the backend shortlist) and execute the exit plan, or consciously re-decide. Do not let the experiment lapse silently.

--- a/context/software.md
+++ b/context/software.md
@@ -73,6 +73,7 @@ Secondary-domain HTTPRoutes require an explicit `DNSEndpoint` — see `kubernete
 |---|---|---|
 | kube-prometheus-stack | Metrics (Prometheus + Alertmanager + Grafana). | Deployed on Longhorn PVCs in the `observability` namespace; ADR 0007. |
 | OpenTelemetry (logs + traces) | Logs and traces pipeline. | Deferred roadmap — see [ADR 0008](adrs/0008-opentelemetry-based-logs-and-traces-roadmap.md). |
+| ClickStack (ClickHouse + OTel + HyperDX) | Logs/traces backend eval (bundled ClickHouse, Keeper, OTel collector, MongoDB, HyperDX UI). | **EXPERIMENT** — 60-day throwaway learning eval in the `clickstack` namespace; **review-by 2026-08-02**; [ADR 0028](adrs/0028-clickstack-learning-experiment.md). Metrics stay on Prometheus; logs/traces pillar only. See [note](../docs/docs/notes/clickstack-experiment.md). |
 
 ## Tooling (runs on the operator's machine, not the cluster)
 

--- a/docs/docs/notes/clickstack-experiment.md
+++ b/docs/docs/notes/clickstack-experiment.md
@@ -1,0 +1,153 @@
+# ClickStack experiment — baseline & operations
+
+Baseline / operations artifact for the **ClickStack 60-day learning experiment** ([ADR 0028](https://github.com/wcygan/anton/blob/main/context/adrs/0028-clickstack-learning-experiment.md)). Captures what was deployed, the manifest layout, the endpoint surface, the 1Password item the operator still has to create, the containment rules that keep this learning rather than creep, and the hard exit obligation on **2026-08-02**.
+
+> This is a **throwaway eval**, not a production adoption. ADR 0028 does **not** supersede ADR 0007 (kube-prometheus-stack for metrics) or ADR 0008 (the deferred logs+traces roadmap). The deliverable is a successor ADR to 0008 that either confirms the VictoriaLogs+Jaeger shortlist or re-ranks toward ClickHouse/HyperDX — backed by evidence from this run. Metrics stay 100% on Prometheus throughout.
+
+## What was deployed
+
+ClickStack is ClickHouse's productized observability stack. We deploy it **as-shipped** — bundled ClickHouse + Keeper + OTel collector + MongoDB + HyperDX — to evaluate ClickStack itself, not an externalized assembly of production components. The install is **two-phase**, using the official ClickHouse-maintained Helm repo `https://clickhouse.github.io/ClickStack-helm-charts` (a classic gh-pages Helm repo, not OCI — same upstream-forced `HelmRepository` deviation as Longhorn / SeaweedFS).
+
+| Phase | Flux Kustomization | Chart | Version | What it installs |
+|---|---|---|---|---|
+| 1 | `clickstack-operators` | `clickstack-operators` | 1.0.0 | The new **ClickHouse Kubernetes Operator** (`ClickHouseCluster` + `KeeperCluster` CRDs — **not** Altinity's `clickhouse-operator` / `ClickHouseInstallation`) and the **MongoDB Community Operator (MCK)** |
+| 2 | `clickstack-app` | `clickstack` | 3.0.0 (appVersion 2.27.0) | HyperDX (UI/API), the OTel collector, and the `ClickHouseCluster` / `KeeperCluster` / `MongoDBCommunity` custom resources the Phase-1 operators reconcile |
+
+Phase 2 `dependsOn` Phase 1 (plus `external-secrets` for the credential pull and `envoy-gateway` for the HTTPRoute CRD), and Phase 1's Kustomization sets `wait: true` so the operators must report `Ready=True` before the main chart applies any CR. Two-phase ordering follows ADR 0027.
+
+Both chart versions are **pinned** (no ranges) per ADR 0028 — young charts, single published version each; Renovate owns the bump.
+
+### Component shape (chart as-shipped)
+
+| Component | Backed by | Notes |
+|---|---|---|
+| ClickHouse | `ClickHouseCluster` CR | Single replica (fine for a throwaway eval). **Explicit resource limits — ADR 0028 hard requirement:** requests `1` CPU / `4Gi`, limits `4` CPU / `8Gi`; `20Gi` data PVC |
+| ClickHouse Keeper | `KeeperCluster` CR | `5Gi` data PVC |
+| MongoDB | `MongoDBCommunity` CR | HyperDX app metadata store. Resources set via the CRD's `spec.statefulSet` override (container name `mongod`), **not** a top-level `mongodb.resources` key (read by no template) |
+| OTel collector | Deployment (not DaemonSet) | Receives OTLP (`4317` gRPC / `4318` HTTP), writes to ClickHouse. Does **not** scrape pod logs by default |
+| HyperDX | Deployment `clickstack-app` | Lucene/SQL UI for logs/traces. ClusterIP service; chart Ingress disabled — Gateway API owns exposure |
+
+### Naming gotcha worth remembering
+
+Release name is `clickstack`, but the chart's `clickstack.hyperdx.fullname` helper **appends `-app`** — so the HyperDX Deployment and Service render as **`clickstack-app`**. The HTTPRoute `backendRef` and the `clickstack-app` Kustomization `healthChecks` both reference that name. A top-level `fullnameOverride` is deliberately **not** used: the helper would also rename ClickHouse/Keeper/MongoDB while the OTel service name stays release-name-derived, desyncing the chart's internal service wiring.
+
+## Manifest layout
+
+Standard anton 3-file Flux pattern, one namespace dir with two apps (the two install phases):
+
+```
+kubernetes/apps/clickstack/
+  namespace.yaml                          # creates clickstack ns (prune disabled)
+  kustomization.yaml                      # components: ../../components/sops; lists both ks.yaml
+  clickstack-operators/                   # PHASE 1
+    ks.yaml                               # wait: true; postBuild substituteFrom cluster-secrets
+    app/
+      kustomization.yaml
+      helmrepository.yaml                 # source name `clickstack`
+      helmrelease.yaml                    # chart clickstack-operators 1.0.0, values: {}
+  clickstack-app/                         # PHASE 2
+    ks.yaml                               # dependsOn [operators, external-secrets, envoy-gateway]
+    app/
+      kustomization.yaml
+      helmrepository.yaml                 # source name `clickstack-charts` (see note below)
+      helmrelease.yaml                    # chart clickstack 3.0.0; ESO creds via valuesFrom
+      externalsecret.yaml                 # ESO → clickstack-credentials Secret
+      httproute.yaml                      # envoy-internal/https → clickstack-app:3000
+```
+
+Two `HelmRepository` objects point at the **same upstream URL** but carry **distinct names** (`clickstack` vs `clickstack-charts`). Both Kustomizations target the `clickstack` namespace, so a shared name would make two Flux Kustomizations co-own one object and fight over SSA field ownership every reconcile; anton's 3-file-pattern hook also requires each app dir to ship its own source.
+
+> Note: the `cluster-apps` Kustomization (`kubernetes/flux/cluster/ks.yaml`) points at `./kubernetes/apps` with no aggregating `kustomization.yaml`, so a new namespace directory that mirrors the existing ones (e.g. `kubernetes/apps/storage/`) is discovered automatically — no parent file needs editing.
+
+## Endpoint surface
+
+| Surface | Address | Notes |
+|---|---|---|
+| HyperDX UI (LAN) | `https://hyperdx.${SECRET_DOMAIN}` | Via `envoy-internal` Gateway (`https` listener) + the `hyperdx` HTTPRoute → `clickstack-app:3000`. Split-horizon DNS through `k8s_gateway` |
+| HyperDX UI (tailnet) | `https://hyperdx.<tailnet>.ts.net` | Via the `tailscale` IngressClass (`hyperdx-tailscale-ingress` app → `clickstack-app:3000`). Off-LAN access per ADR 0012, mirrors `hubble-tailscale-ingress`. Tailnet-internal, not public |
+| OTLP ingest (in-cluster) | OTel collector service, `4317` (gRPC) / `4318` (HTTP) | How workloads ship telemetry into ClickStack |
+
+`${SECRET_DOMAIN}` is substituted by Flux `postBuild.substituteFrom` from the `cluster-secrets` Secret — never hardcode the domain.
+
+**Internal-only, by ADR 0028 containment.** The HyperDX UI is reachable two internal ways: on-LAN via `envoy-internal` (Gateway API HTTPRoute) and off-LAN via the `tailscale` IngressClass (tailnet MagicDNS, per ADR 0012). Both are internal — **no** Cloudflare tunnel, **no** `envoy-external` binding, **no** `DNSEndpoint`, **no** public exposure. The chart's built-in Ingress is disabled (`hyperdx.ingress.enabled: false`). Note: ADR 0028's body says "envoy-internal HTTPRoute only"; the tailnet Ingress is a same-spirit internal addition (the operator asked for Tailscale access) — record it in the 0028 review.
+
+## Credential retrieval — open item
+
+ClickStack uses **ESO**, not SOPS. The `ExternalSecret clickstack-credentials` pulls four runtime credentials from **1Password vault `anton`**, item **`clickstack`**, via the `onepassword-connect` `ClusterSecretStore` (`onepasswordSDK` provider, combined-key syntax `<item>/<field>`).
+
+> **OPEN ITEM — the 1Password item `clickstack` does NOT yet exist.** The operator must create it with these four fields before the ExternalSecret can resolve and Phase 2 can become Ready. No secret values were invented or committed — only the manifest references them.
+
+| 1Password field | Purpose |
+|---|---|
+| `HYPERDX_API_KEY` | HyperDX app secret / API key |
+| `CLICKHOUSE_PASSWORD` | The `otelcollector` ClickHouse user password |
+| `CLICKHOUSE_APP_PASSWORD` | The `app` ClickHouse user password |
+| `MONGODB_PASSWORD` | MongoDB password |
+
+These **override the chart's weak default passwords** (an ADR 0028 hard requirement). The chart offers **no** `existingSecret` hook for these four runtime credentials — they are plain Helm values under `hyperdx.secrets.*`. So the flow is indirect:
+
+1. ESO writes `Secret/clickstack-credentials` (four keys) from the 1Password item.
+2. The `clickstack` HelmRelease injects each key into the values tree via `valuesFrom` + `targetPath: hyperdx.secrets.*`.
+3. Helm templates the values into the running pods.
+
+The ESO Secret is deliberately named `clickstack-credentials`, **not** `clickstack-secret`: the chart's `hyperdx/secret.yaml` template unconditionally renders its own `clickstack-secret` whenever `hyperdx.secrets` is non-nil (always, here), so an ESO target of the same name would put ESO and Helm in an ownership fight over one Secret. Only Flux reads the ESO Secret (by `valuesKey`), so its name is free to differ.
+
+## Containment rules (ADR 0028)
+
+These are load-bearing — they are what keep this a learning experiment instead of scope creep. **Pillar separation is the key rule.**
+
+- **Own `clickstack` namespace only.** Nothing else `dependsOn` it.
+- **Metrics stay 100% on kube-prometheus-stack, untouched.** ClickStack must not replace Prometheus, must not become a second metrics store, and must **not** bridge Prometheus metrics into ClickHouse during the eval. ClickStack owns **only** the logs+traces pillar. Bridging metrics would build the two-store mess ADR 0008 rejected and muddy the result.
+- **No ServiceMonitors that fork production metrics** into ClickHouse.
+- **Explicit ClickHouse resource limits** (set in the HelmRelease — see component table above).
+- **HyperDX UI via `envoy-internal` HTTPRoute only** — no Cloudflare tunnel, no `envoy-external`.
+- **Test signal is deliberately chosen, not a metrics fork:** pod logs via the OTel filelog receiver + Temporal's OTLP traces. Wiring that signal (filelog receiver config + pointing Temporal's OTLP export at the collector) is an **operational follow-up**, not part of this scaffold — and the Temporal app manifests are intentionally **not** edited here.
+
+## Exit obligation — review by 2026-08-02
+
+A learning intake without an enforced review date becomes permanent intake. The `review-by: 2026-08-02` field in ADR 0028 is load-bearing. At that date, do one of:
+
+- **Tear down** — write the ADR 0008 successor (confirm or re-rank the logs/traces backend shortlist with evidence), then execute the exit plan below; **or**
+- **Consciously re-decide** — explicitly, in a new ADR. Do not let the experiment lapse silently.
+
+The four success criteria the successor ADR must answer (from ADR 0028):
+
+1. Does ClickHouse-backed wide-events querying meaningfully beat VictoriaLogs for the cross-pod / ≥24h questions ADR 0008 Trigger 1 describes?
+2. Is "ClickHouse is too heavy" still true at homelab scale (~85 GiB free RAM/node)? Measure real CPU/RAM/operational cost of ClickHouse + Keeper + MongoDB + HyperDX vs a VictoriaLogs single binary.
+3. Is HyperDX's wide-events UX worth abandoning Grafana-as-front-door, or does running two UIs confirm 0008's fragmentation concern?
+4. Does it stay contained, or drift toward a second metrics store (the containment test itself)?
+
+### Exit plan
+
+Eval data is throwaway; no production signal ever depends on it.
+
+```sh
+# 1. Suspend Flux so it stops reconciling the apps mid-teardown.
+flux suspend kustomization clickstack-app clickstack-operators -n flux-system
+
+# 2. Delete the custom resources first (operators GC their children), then the namespace.
+kubectl -n clickstack delete clickhousecluster --all
+kubectl -n clickstack delete keepercluster --all
+kubectl -n clickstack delete mongodbcommunity --all
+kubectl delete namespace clickstack   # destructive — confirm intent
+
+# 3. Remove the manifests from Git: drop ./clickstack from the parent apps kustomization,
+#    delete kubernetes/apps/clickstack/, commit, push, reconcile. Flux owns deletion.
+
+# 4. Remove the two operators' cluster-scoped CRDs left behind. List them first
+#    to get the exact CRD names/API groups, then delete:
+kubectl get crd | grep -iE 'mongodbcommunity|clickhouse|keeper'
+# kubectl delete crd <clickhousecluster-crd> <keepercluster-crd> <mongodbcommunity-crd>
+
+# 5. Delete the 1Password item `clickstack` from vault `anton` once nothing references it.
+```
+
+> `kubectl delete namespace` is a hard rule destructive op — only with explicit confirmation. Verify the kube context before running anything mutating.
+
+## Pointers
+
+- Decision: [`context/adrs/0028-clickstack-learning-experiment.md`](https://github.com/wcygan/anton/blob/main/context/adrs/0028-clickstack-learning-experiment.md)
+- Anchored against: [ADR 0007](https://github.com/wcygan/anton/blob/main/context/adrs/0007-adopt-kube-prometheus-stack.md) (metrics baseline, untouched) and [ADR 0008](https://github.com/wcygan/anton/blob/main/context/adrs/0008-opentelemetry-logs-and-traces-roadmap.md) (the logs+traces roadmap this experiment informs)
+- Platform `dependsOn` convention: [ADR 0027](https://github.com/wcygan/anton/blob/main/context/adrs/0027-platform-dependson-rule.md)
+- Manifests: `kubernetes/apps/clickstack/`
+- Upstream charts: https://github.com/ClickHouse/ClickStack-helm-charts

--- a/kubernetes/apps/clickstack/clickstack-app/app/externalsecret.yaml
+++ b/kubernetes/apps/clickstack/clickstack-app/app/externalsecret.yaml
@@ -1,0 +1,48 @@
+---
+# ClusterSecretStore `onepassword-connect` uses the `onepasswordSDK` provider
+# (vault `anton`), which requires the combined-key syntax "<item-title>/<field-name>".
+#
+# OPEN ITEM: the 1Password item `clickstack` does NOT yet exist — the operator
+# must create it with these four fields before this ExternalSecret can resolve:
+#   - HYPERDX_API_KEY        (HyperDX app secret / API key)
+#   - CLICKHOUSE_PASSWORD    (the 'otelcollector' ClickHouse user password)
+#   - CLICKHOUSE_APP_PASSWORD (the 'app' ClickHouse user password)
+#   - MONGODB_PASSWORD       (MongoDB password)
+#
+# These OVERRIDE the chart's weak default passwords (ADR 0028 requires this).
+# The chart offers NO existingSecret hook for these four runtime credentials, so
+# the HelmRelease injects them via Flux `valuesFrom` -> `targetPath:
+# hyperdx.secrets.*`, reading the generated `clickstack-credentials` keys below.
+#
+# Target is `clickstack-credentials`, NOT `clickstack-secret`: the chart's
+# hyperdx/secret.yaml template renders its own `clickstack-secret` whenever
+# hyperdx.secrets is non-nil (it always is here), so an ESO target of the same
+# name would put ESO and Helm in an ownership fight over one Secret. Only Flux
+# reads this ESO Secret (by valuesKey), so its name is free to differ.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: clickstack-credentials
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: clickstack-credentials
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+  data:
+    - secretKey: HYPERDX_API_KEY
+      remoteRef:
+        key: "clickstack/HYPERDX_API_KEY"
+    - secretKey: CLICKHOUSE_PASSWORD
+      remoteRef:
+        key: "clickstack/CLICKHOUSE_PASSWORD"
+    - secretKey: CLICKHOUSE_APP_PASSWORD
+      remoteRef:
+        key: "clickstack/CLICKHOUSE_APP_PASSWORD"
+    - secretKey: MONGODB_PASSWORD
+      remoteRef:
+        key: "clickstack/MONGODB_PASSWORD"

--- a/kubernetes/apps/clickstack/clickstack-app/app/helmrelease.yaml
+++ b/kubernetes/apps/clickstack/clickstack-app/app/helmrelease.yaml
@@ -1,0 +1,133 @@
+---
+# Phase 2 of the two-phase ClickStack install (ADR 0028). Evaluates ClickStack
+# as-shipped: bundled ClickHouse + Keeper + OTel collector + MongoDB + HyperDX.
+# Release name `clickstack`; the chart's `clickstack.hyperdx.fullname` helper
+# appends `-app`, so the HyperDX Deployment and Service render as
+# `clickstack-app` (the HTTPRoute backendRef and ks.yaml healthCheck reference
+# that name). A top-level fullnameOverride is deliberately NOT used: the helper
+# would also rename ClickHouse/Keeper/MongoDB while the OTel service name stays
+# release-name-derived, desyncing the chart's internal service wiring.
+#
+# 60-day throwaway learning eval — single-replica ClickHouse/Keeper is fine.
+# Containment per ADR 0028: own namespace only, no Prometheus->ClickHouse
+# bridge, no ServiceMonitor forking prod metrics, explicit ClickHouse limits,
+# UI via envoy-internal HTTPRoute only.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: clickstack
+spec:
+  releaseName: clickstack
+  chart:
+    spec:
+      chart: clickstack
+      # Pinned per ADR 0028 — young chart (appVersion 2.27.0), single published
+      # version. No ranges; Renovate owns the bump.
+      version: 3.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: clickstack-charts
+      interval: 15m
+  interval: 1h
+  # The four runtime credentials have NO chart-native existingSecret hook — they
+  # are plain Helm values under hyperdx.secrets.*. ESO writes them into
+  # `clickstack-credentials`; Flux injects each into the values tree via
+  # valuesFrom + targetPath, overriding the chart's weak default passwords
+  # (ADR 0028). The ESO Secret is deliberately NOT named `clickstack-secret`:
+  # the chart's hyperdx/secret.yaml template unconditionally renders its own
+  # `clickstack-secret` (because hyperdx.secrets stays non-nil), so an ESO
+  # target of the same name would make ESO and Helm fight to own one Secret.
+  # The chart reads these values via Helm templating, never the ESO Secret by
+  # name, so the ESO Secret name is free to differ.
+  valuesFrom:
+    - kind: Secret
+      name: clickstack-credentials
+      valuesKey: HYPERDX_API_KEY
+      targetPath: hyperdx.secrets.HYPERDX_API_KEY
+    - kind: Secret
+      name: clickstack-credentials
+      valuesKey: CLICKHOUSE_PASSWORD
+      targetPath: hyperdx.secrets.CLICKHOUSE_PASSWORD
+    - kind: Secret
+      name: clickstack-credentials
+      valuesKey: CLICKHOUSE_APP_PASSWORD
+      targetPath: hyperdx.secrets.CLICKHOUSE_APP_PASSWORD
+    - kind: Secret
+      name: clickstack-credentials
+      valuesKey: MONGODB_PASSWORD
+      targetPath: hyperdx.secrets.MONGODB_PASSWORD
+  values:
+    hyperdx:
+      # ClusterIP UI/API service; exposure is via Gateway API HTTPRoute, not the
+      # chart Ingress. Disabled explicitly (already the v3.0.0 default).
+      service:
+        type: ClusterIP
+      ingress:
+        enabled: false
+      # The data-source config (connections.json / sources.json) hook is SEPARATE
+      # from the four passwords above and is NOT used here — leave HyperDX to seed
+      # its own sources for the eval.
+      deployment:
+        useExistingConfigSecret: false
+
+    # Bundled components — evaluate ClickStack as-shipped (ADR 0028).
+    clickhouse:
+      enabled: true
+      cluster:
+        spec:
+          containerTemplate:
+            # Explicit ClickHouse resource limits are an ADR 0028 hard requirement
+            # (containment). Compute is separate from storage below.
+            resources:
+              requests:
+                cpu: "1"
+                memory: 4Gi
+              limits:
+                cpu: "4"
+                memory: 8Gi
+          dataVolumeClaimSpec:
+            resources:
+              requests:
+                storage: 20Gi
+      keeper:
+        spec:
+          dataVolumeClaimSpec:
+            resources:
+              requests:
+                storage: 5Gi
+
+    mongodb:
+      enabled: true
+      # The chart renders only `mongodb.spec` verbatim into the MongoDBCommunity
+      # CR — a top-level `mongodb.resources` key is read by no template and has
+      # no effect. Resources for the mongod container go through the CRD's
+      # statefulSet override (spec.statefulSet.spec.template.spec.containers,
+      # container name `mongod`).
+      spec:
+        statefulSet:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: mongod
+                    resources:
+                      requests:
+                        cpu: 250m
+                        memory: 512Mi
+                      limits:
+                        cpu: "1"
+                        memory: 1Gi
+
+    # Deployment-mode collector (NOT a daemonset): receives app telemetry via
+    # OTLP (4317 gRPC / 4318 HTTP) and writes to ClickHouse. It does not scrape
+    # pod logs by default — wiring the test signal (filelog + Temporal OTLP) is
+    # an operational follow-up, not part of this scaffold (ADR 0028).
+    otel-collector:
+      enabled: true
+      resources:
+        requests:
+          cpu: 250m
+          memory: 512Mi
+        limits:
+          cpu: "1"
+          memory: 1Gi

--- a/kubernetes/apps/clickstack/clickstack-app/app/helmrepository.yaml
+++ b/kubernetes/apps/clickstack/clickstack-app/app/helmrepository.yaml
@@ -1,0 +1,17 @@
+---
+# ClickStack publishes a classic Helm repo on gh-pages, not an OCI chart — so
+# we use HelmRepository (same upstream-forced deviation as Longhorn / SeaweedFS).
+#
+# Distinct name from the operators app's `clickstack` source: both Kustomizations
+# target the `clickstack` namespace, so a shared name would make two different
+# Flux Kustomizations co-own one HelmRepository object and fight over its SSA
+# field ownership on every reconcile. anton's 3-file-pattern hook also requires
+# each app dir to ship its own source, so a per-app uniquely-named source
+# satisfies both constraints.
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: clickstack-charts
+spec:
+  interval: 1h
+  url: https://clickhouse.github.io/ClickStack-helm-charts

--- a/kubernetes/apps/clickstack/clickstack-app/app/httproute.yaml
+++ b/kubernetes/apps/clickstack/clickstack-app/app/httproute.yaml
@@ -1,0 +1,24 @@
+---
+# Internal-only per ADR 0028 — no Cloudflare tunnel, no `envoy-external`.
+# Exposes the HyperDX web UI. The chart's built-in Ingress is disabled
+# (hyperdx.ingress.enabled: false) — Gateway API owns exposure here.
+# Service `clickstack-app`: the chart's `clickstack.hyperdx.fullname` helper
+# appends `-app` to the release name `clickstack`. App/UI port 3000
+# (hyperdx.ports.app).
+# `${SECRET_DOMAIN}` is substituted by Flux from the `cluster-secrets` Secret
+# via the clickstack-app Kustomization's postBuild.substituteFrom.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: hyperdx
+spec:
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+      sectionName: https
+  hostnames:
+    - hyperdx.${SECRET_DOMAIN}
+  rules:
+    - backendRefs:
+        - name: clickstack-app
+          port: 3000

--- a/kubernetes/apps/clickstack/clickstack-app/app/kustomization.yaml
+++ b/kubernetes/apps/clickstack/clickstack-app/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrepository.yaml
+  - ./helmrelease.yaml
+  - ./externalsecret.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/clickstack/clickstack-app/ks.yaml
+++ b/kubernetes/apps/clickstack/clickstack-app/ks.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: clickstack-app
+spec:
+  interval: 1h
+  # Phase 2 of the two-phase install. `dependsOn` the operators Kustomization so
+  # the ClickHouseCluster / KeeperCluster / MongoDBCommunity CRDs exist before
+  # this chart renders the CRs (ADR 0028 / ADR 0027). `external-secrets` gates
+  # the ExternalSecret pulling the four runtime credentials from 1Password;
+  # `envoy-gateway` gates the `envoy-internal/https` HTTPRoute CRD.
+  dependsOn:
+    - name: clickstack-operators
+    - name: external-secrets
+      namespace: external-secrets
+    - name: envoy-gateway
+      namespace: network
+  path: ./kubernetes/apps/clickstack/clickstack-app/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: clickstack
+  # Check the runtime resources directly: the HyperDX Deployment Ready
+  # (clickstack-app — the chart's hyperdx fullname helper appends `-app`), the
+  # ESO-managed credential Secret present (clickstack-credentials — its keys
+  # feed the HelmRelease via valuesFrom), and the HTTPRoute accepted.
+  healthChecks:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: clickstack-app
+      namespace: clickstack
+    - apiVersion: v1
+      kind: Secret
+      name: clickstack-credentials
+      namespace: clickstack
+    - apiVersion: gateway.networking.k8s.io/v1
+      kind: HTTPRoute
+      name: hyperdx
+      namespace: clickstack
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret

--- a/kubernetes/apps/clickstack/clickstack-operators/app/helmrelease.yaml
+++ b/kubernetes/apps/clickstack/clickstack-operators/app/helmrelease.yaml
@@ -1,0 +1,23 @@
+---
+# Phase 1 of the two-phase ClickStack install (ADR 0028). Bundles the new
+# ClickHouse Kubernetes Operator (ClickHouseCluster + KeeperCluster CRDs — NOT
+# Altinity's clickhouse-operator / ClickHouseInstallation) and the MongoDB
+# Community Operator (MCK). The main `clickstack` chart renders the CRs that
+# these operators reconcile, so this must reach Ready before `clickstack-app`.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: clickstack-operators
+spec:
+  chart:
+    spec:
+      chart: clickstack-operators
+      # Pinned per ADR 0028 — young chart, single published version. No ranges;
+      # Renovate owns the bump.
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: clickstack
+      interval: 15m
+  interval: 1h
+  values: {}

--- a/kubernetes/apps/clickstack/clickstack-operators/app/helmrepository.yaml
+++ b/kubernetes/apps/clickstack/clickstack-operators/app/helmrepository.yaml
@@ -1,0 +1,11 @@
+---
+# ClickStack publishes a classic Helm repo on gh-pages, not an OCI chart — so
+# we use HelmRepository (same upstream-forced deviation as Longhorn / SeaweedFS).
+# Shared by both the operators HelmRelease and the main clickstack HelmRelease.
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: clickstack
+spec:
+  interval: 1h
+  url: https://clickhouse.github.io/ClickStack-helm-charts

--- a/kubernetes/apps/clickstack/clickstack-operators/app/kustomization.yaml
+++ b/kubernetes/apps/clickstack/clickstack-operators/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/clickstack/clickstack-operators/ks.yaml
+++ b/kubernetes/apps/clickstack/clickstack-operators/ks.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: clickstack-operators
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/clickstack/clickstack-operators/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: clickstack
+  # `wait: true` so `clickstack-app` (via `dependsOn`) blocks until the operators
+  # HelmRelease reports Ready=True — the ClickHouse operator (ClickHouseCluster /
+  # KeeperCluster CRDs) and the MongoDB MCK operator must be installed before the
+  # main chart applies the CRs. Two-phase install per ADR 0028 / ADR 0027.
+  wait: true
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret

--- a/kubernetes/apps/clickstack/hyperdx-tailscale-ingress/app/ingress.yaml
+++ b/kubernetes/apps/clickstack/hyperdx-tailscale-ingress/app/ingress.yaml
@@ -1,0 +1,21 @@
+---
+# Exposes the HyperDX UI on the tailnet at hyperdx.<tailnet>.ts.net via the
+# tailscale operator's IngressClass (mirrors kube-system/hubble-tailscale-ingress).
+# Backend is the chart's HyperDX Service `clickstack-app` (the chart's
+# `clickstack.hyperdx.fullname` helper appends `-app` to release name `clickstack`)
+# on the app/UI port 3000. Tailnet-internal only — no public exposure (ADR 0028).
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: hyperdx
+  namespace: clickstack
+spec:
+  ingressClassName: tailscale
+  tls:
+    - hosts:
+        - hyperdx
+  defaultBackend:
+    service:
+      name: clickstack-app
+      port:
+        number: 3000

--- a/kubernetes/apps/clickstack/hyperdx-tailscale-ingress/app/kustomization.yaml
+++ b/kubernetes/apps/clickstack/hyperdx-tailscale-ingress/app/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ingress.yaml

--- a/kubernetes/apps/clickstack/hyperdx-tailscale-ingress/ks.yaml
+++ b/kubernetes/apps/clickstack/hyperdx-tailscale-ingress/ks.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: hyperdx-tailscale-ingress
+spec:
+  interval: 1h
+  # Puts the HyperDX UI on the tailnet at hyperdx.<tailnet>.ts.net via the
+  # tailscale IngressClass (same pattern as kube-system/hubble-tailscale-ingress).
+  # This is tailnet-internal remote access per ADR 0012 — NOT a public exposure
+  # (no Cloudflare tunnel / envoy-external), so it stays inside ADR 0028's
+  # "internal-only" intent. The envoy-internal HTTPRoute (clickstack-app) remains
+  # the on-LAN path; this adds off-LAN tailnet access.
+  # `dependsOn` the workload so the clickstack-app Service exists before the
+  # Ingress backend resolves.
+  dependsOn:
+    - name: clickstack-app
+  path: ./kubernetes/apps/clickstack/hyperdx-tailscale-ingress/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: clickstack
+  wait: false

--- a/kubernetes/apps/clickstack/kustomization.yaml
+++ b/kubernetes/apps/clickstack/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: clickstack
+
+components:
+  - ../../components/sops
+
+resources:
+  - ./namespace.yaml
+  - ./clickstack-operators/ks.yaml
+  - ./clickstack-app/ks.yaml
+  - ./hyperdx-tailscale-ingress/ks.yaml

--- a/kubernetes/apps/clickstack/namespace.yaml
+++ b/kubernetes/apps/clickstack/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: clickstack
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled


### PR DESCRIPTION
Two-phase ClickStack install (operators -> app) in a contained clickstack
namespace per ADR 0028 (60-day learning eval, review-by 2026-08-02).
HyperDX UI exposed on-LAN via envoy-internal HTTPRoute and off-LAN via a
tailscale IngressClass. Creds via ESO from 1Password item 'clickstack'.
Metrics stay on Prometheus; logs/traces pillar only.

Adds clickstack-ops skill + experiment doc note.
