### PR TITLE
fix: restrict Harbor Dragonfly ingress

### DIFF
--- a/kubernetes/apps/registries/harbor-config/app/dragonfly.yaml
+++ b/kubernetes/apps/registries/harbor-config/app/dragonfly.yaml
@@ -6,6 +6,9 @@ metadata:
 spec:
   replicas: 3
   image: docker.dragonflydb.io/dragonflydb/dragonfly:v1.39.0
+  # The operator's generated policy leaves Redis open to every source. Keep
+  # policy ownership in GitOps so Harbor and operator access stay explicit.
+  networkPolicyEnabled: false
 
   affinity:
     podAntiAffinity:

--- a/kubernetes/apps/registries/harbor-config/app/kustomization.yaml
+++ b/kubernetes/apps/registries/harbor-config/app/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - ./postgres-cluster.yaml
   - ./dragonfly.yaml
+  - ./networkpolicy-dragonfly.yaml
   - ./externalsecret-admin.yaml
   - ./externalsecret-s3.yaml
   - ./ingress-tailscale.yaml

--- a/kubernetes/apps/registries/harbor-config/app/networkpolicy-dragonfly.yaml
+++ b/kubernetes/apps/registries/harbor-config/app/networkpolicy-dragonfly.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: harbor-redis-restricted
+spec:
+  podSelector:
+    matchLabels:
+      app: harbor-redis
+      app.kubernetes.io/name: dragonfly
+      app.kubernetes.io/part-of: dragonfly
+  policyTypes:
+    - Ingress
+  ingress:
+    # Redis clients: Harbor, the operator, and Dragonfly replication peers.
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: harbor
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: databases
+          podSelector:
+            matchLabels:
+              control-plane: controller-manager
+        - podSelector:
+            matchLabels:
+              app: harbor-redis
+              app.kubernetes.io/name: dragonfly
+              app.kubernetes.io/part-of: dragonfly
+      ports:
+        - protocol: TCP
+          port: 6379
+    # Dragonfly's unauthenticated admin endpoint is only for its operator and peers.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: databases
+          podSelector:
+            matchLabels:
+              control-plane: controller-manager
+        - podSelector:
+            matchLabels:
+              app: harbor-redis
+              app.kubernetes.io/name: dragonfly
+              app.kubernetes.io/part-of: dragonfly
+      ports:
+        - protocol: TCP
+          port: 9999


### PR DESCRIPTION
## Summary

Replace the Dragonfly operator's generated allow-all Redis ingress policy with a GitOps-owned least-privilege policy for Harbor Redis.

## Changes

- Disable the operator-generated `NetworkPolicy/harbor-redis`.
- Add `NetworkPolicy/harbor-redis-restricted` with explicit Harbor, Dragonfly operator, and peer selectors.
- Keep TCP 9999 restricted to the operator and Dragonfly peers.

## Reproduction / validation

```sh
yq . kubernetes/apps/registries/harbor-config/app/dragonfly.yaml
yq . kubernetes/apps/registries/harbor-config/app/networkpolicy-dragonfly.yaml
yq . kubernetes/apps/registries/harbor-config/app/kustomization.yaml
kubectl kustomize kubernetes/apps/registries/harbor-config/app
kubectl -n registries apply --dry-run=server -k kubernetes/apps/registries/harbor-config/app
git diff --check
```