### PR TITLE
feat: harden public edge availability

### DIFF
--- a/.github/workflows/public-uptime.yaml
+++ b/.github/workflows/public-uptime.yaml
@@ -1,0 +1,20 @@
+---
+name: Public uptime
+
+on:
+  schedule:
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Check public DNS, TLS, HTTP, and TTFB
+        run: bash scripts/check-public-uptime.sh

--- a/kubernetes/apps/bakery-site/server/app/helmrelease.yaml
+++ b/kubernetes/apps/bakery-site/server/app/helmrelease.yaml
@@ -12,7 +12,20 @@ spec:
   values:
     controllers:
       server:
+        replicas: 2
         strategy: RollingUpdate
+        pod:
+          topologySpreadConstraints:
+            - maxSkew: 1
+              topologyKey: kubernetes.io/hostname
+              whenUnsatisfiable: DoNotSchedule
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/controller: server
+                  app.kubernetes.io/instance: bakery-server
+                  app.kubernetes.io/name: bakery-server
+        podDisruptionBudget:
+          minAvailable: 1
         containers:
           app:
             image:

--- a/kubernetes/apps/default/echo/app/helmrelease.yaml
+++ b/kubernetes/apps/default/echo/app/helmrelease.yaml
@@ -12,7 +12,20 @@ spec:
   values:
     controllers:
       echo:
+        replicas: 2
         strategy: RollingUpdate
+        pod:
+          topologySpreadConstraints:
+            - maxSkew: 1
+              topologyKey: kubernetes.io/hostname
+              whenUnsatisfiable: DoNotSchedule
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/controller: echo
+                  app.kubernetes.io/instance: echo
+                  app.kubernetes.io/name: echo
+        podDisruptionBudget:
+          minAvailable: 1
         containers:
           app:
             image:

--- a/kubernetes/apps/default/homepage/app/deployment.yaml
+++ b/kubernetes/apps/default/homepage/app/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: homepage
 spec:
-  replicas: 1
+  replicas: 2
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -17,6 +17,13 @@ spec:
       labels:
         app.kubernetes.io/name: homepage
     spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: homepage
       automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true

--- a/kubernetes/apps/default/homepage/app/kustomization.yaml
+++ b/kubernetes/apps/default/homepage/app/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./deployment.yaml
+  - ./poddisruptionbudget.yaml
   - ./service.yaml
   - ./httproute.yaml
   - ./dnsendpoint.yaml

--- a/kubernetes/apps/default/homepage/app/poddisruptionbudget.yaml
+++ b/kubernetes/apps/default/homepage/app/poddisruptionbudget.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: homepage
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: homepage

--- a/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
@@ -11,7 +11,20 @@ spec:
   values:
     controllers:
       cloudflare-tunnel:
+        replicas: 2
         strategy: RollingUpdate
+        pod:
+          topologySpreadConstraints:
+            - maxSkew: 1
+              topologyKey: kubernetes.io/hostname
+              whenUnsatisfiable: DoNotSchedule
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/controller: cloudflare-tunnel
+                  app.kubernetes.io/instance: cloudflare-tunnel
+                  app.kubernetes.io/name: cloudflare-tunnel
+        podDisruptionBudget:
+          minAvailable: 1
         annotations:
           reloader.stakater.com/auto: "true"
         containers:

--- a/kubernetes/apps/network/envoy-gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/helmrelease.yaml
@@ -15,7 +15,20 @@ spec:
     # EnvoyProxy data-plane config. The data-plane priority is set on the
     # EnvoyProxy CR in envoy.yaml, not here.
     deployment:
+      replicas: 2
       priorityClassName: system-cluster-critical
+      pod:
+        topologySpreadConstraints:
+          - maxSkew: 1
+            topologyKey: kubernetes.io/hostname
+            whenUnsatisfiable: DoNotSchedule
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/instance: envoy-gateway
+                app.kubernetes.io/name: gateway-helm
+                control-plane: envoy-gateway
+    podDisruptionBudget:
+      minAvailable: 1
     config:
       envoyGateway:
         provider:

--- a/scripts/check-public-uptime.sh
+++ b/scripts/check-public-uptime.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+source "$(dirname "${0}")/lib/common.sh"
+
+readonly TTFB_LIMIT_SECONDS="5"
+readonly ENDPOINTS=(
+  "https://echo.wcygan.net/"
+  "https://cs2plant.nu-sync.net/"
+  "https://nu-sync.net/"
+  "https://kneadybynaturebakery.com/"
+)
+
+check_endpoint() {
+    local endpoint="$1"
+    local host
+    host="${endpoint#https://}"
+    host="${host%%/*}"
+
+    dig +time=5 +tries=1 +short "$host" | awk 'NF { found = 1 } END { exit !found }'
+
+    local response status dns tls ttfb tls_verify
+    response="$(curl --fail --silent --show-error --location --connect-timeout 10 --max-time 20 --retry 1 --retry-delay 1 --retry-max-time 30 --output /dev/null --write-out '%{http_code} %{time_namelookup} %{time_appconnect} %{time_starttransfer} %{ssl_verify_result}' "$endpoint")"
+    read -r status dns tls ttfb tls_verify <<<"$response"
+    [[ "$status" =~ ^[23][0-9][0-9]$ ]]
+    [[ "$tls_verify" = "0" ]]
+    awk -v ttfb="$ttfb" -v limit="$TTFB_LIMIT_SECONDS" 'BEGIN { exit !(ttfb <= limit) }'
+
+    log info "Public endpoint healthy" "endpoint=$endpoint" "dns_seconds=$dns" "tls_seconds=$tls" "tls_verify=$tls_verify" "status=$status" "ttfb_seconds=$ttfb"
+    if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+        printf '| %s | yes (%s) | yes (%s; verify=%s) | %s | %s |\n' "$endpoint" "$dns" "$tls" "$tls_verify" "$status" "$ttfb" >>"$GITHUB_STEP_SUMMARY"
+    fi
+}
+
+main() {
+    check_cli awk curl dig
+    if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+        printf '## Public endpoint uptime\n\nBounded curl: 10s connect, 20s total. TTFB gate: ≤ %ss.\n\n| Endpoint | DNS | TLS | HTTP | TTFB (s) |\n| --- | --- | --- | --- | --- |\n' "$TTFB_LIMIT_SECONDS" >>"$GITHUB_STEP_SUMMARY"
+    fi
+
+    local endpoint
+    for endpoint in "${ENDPOINTS[@]}"; do
+        check_endpoint "$endpoint"
+    done
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Add supported two-replica, hard hostname-spread, and PDB settings for public edge and application workloads, plus a GitHub-hosted DNS/TLS/HTTP/TTFB monitor.

## Validation

- `bash -n scripts/check-public-uptime.sh`
- `bash scripts/check-public-uptime.sh`
- YAML parse and `kubectl kustomize` for affected app paths
- Server-side dry-run of raw homepage Deployment/PDB
- `git diff --check`