### PR TITLE
fix: detect unstable physical fans

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrule-fan-health.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrule-fan-health.yaml
@@ -13,18 +13,24 @@ spec:
     - name: physical-fan-health
       interval: 30s
       rules:
-        - alert: NodePhysicalFanStopped
+        - alert: NodePhysicalFanStoppedOrUnstable
           expr: |
-            (node_hwmon_fan_rpm{sensor=~"fan1|fan2"} == 0)
+            (
+              avg_over_time(
+                (node_hwmon_fan_rpm{sensor=~"fan1|fan2"} == bool 0)[10m:30s]
+              ) >= 0.25
+            )
               * on(instance) group_left(nodename) node_uname_info
           for: 5m
           labels:
             severity: critical
             component: hardware
           annotations:
-            summary: "Physical fan {{ $labels.sensor }} stopped on {{ $labels.nodename }}"
+            summary: "Physical fan {{ $labels.sensor }} stopped or unstable on {{ $labels.nodename }}"
             description: |
-              {{ $labels.nodename }} reports {{ $labels.sensor }} at 0 RPM for
-              at least 5 minutes. Inspect the fan, cabling, and chassis airflow
-              before sustained load causes thermal throttling or a reset.
+              {{ $labels.nodename }} reports {{ $labels.sensor }} at 0 RPM for at
+              least 25% of samples over the last 10 minutes (observed fraction:
+              {{ $value }}). This detects a sustained stop or intermittent stall.
+              Inspect the fan, cabling, and chassis airflow before sustained load
+              causes thermal throttling or a reset.
             runbook_url: "https://github.com/wcygan/anton/blob/main/context/notes/k8s-2-instability/evidence-2026-05-06-k8s-2-fan1-intermittent-failure.md"


### PR DESCRIPTION
## Summary

Replace the instantaneous fan-zero alert predicate with a 10-minute, 30-second-resolution zero-RPM fraction. This preserves the fan1/fan2 hardware scope and detects the observed k8s-2 fan1 intermittent stall without matching healthy or unused channels.

## Changes

- Alert when at least 25% of fan1/fan2 samples are zero over 10 minutes.
- Retain the 5-minute critical alert debounce and node-name join.
- Report the observed zero-RPM fraction in the alert annotation.

## Reproduction / validation

```sh
yq -e '.' kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrule-fan-health.yaml
kubectl kustomize kubernetes/apps/observability/kube-prometheus-stack/app
yq -e '.spec' kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrule-fan-health.yaml | promtool check rules /dev/stdin
git diff --check
```

Live Prometheus validation before publication returned only `k8s-2/fan1` with a zero-RPM fraction of `0.65`.