### PR TITLE
fix(clickstack): pin Keeper image digest

### DIFF
--- a/kubernetes/apps/clickstack/clickstack-app/app/helmrelease.yaml
+++ b/kubernetes/apps/clickstack/clickstack-app/app/helmrelease.yaml
@@ -116,6 +116,13 @@ spec:
                     - query: "GRANT SELECT,INSERT,CREATE,SHOW,ALTER TTL,ALTER MATERIALIZE TTL ON default.*"
       keeper:
         spec:
+          # KeeperCluster supports the image through its container template.
+          # Keep the currently running official 26.5.1.882 build, but make the
+          # version and digest explicit instead of tracking the mutable latest tag.
+          containerTemplate:
+            image:
+              repository: docker.io/clickhouse/clickhouse-keeper:26.5.1.882
+              hash: sha256:1264096f8c73a3e2fbc62cbbaa8cb83089edb4129c2d50f1b9e14c8fb1923cb3
           dataVolumeClaimSpec:
             resources:
               requests:


### PR DESCRIPTION
## Summary

Pin ClickStack Keeper from the mutable `latest` tag to the already-running official 26.5.1.882 image and digest.

## Changes

- Set the supported `KeeperCluster.spec.containerTemplate.image.repository` to the explicit 26.5.1.882 build.
- Set its immutable sha256 digest through the CRD image hash field.

## Reproduction / validation

```sh
yq -e '.' kubernetes/apps/clickstack/clickstack-app/app/helmrelease.yaml
kubectl kustomize kubernetes/apps/clickstack/clickstack-app/app
helm template clickstack clickstack-3.0.0.tgz \
  --set clickhouse.keeper.spec.containerTemplate.image.repository=docker.io/clickhouse/clickhouse-keeper:26.5.1.882 \
  --set clickhouse.keeper.spec.containerTemplate.image.hash=sha256:1264096f8c73a3e2fbc62cbbaa8cb83089edb4129c2d50f1b9e14c8fb1923cb3
git diff --check
```

The rendered KeeperCluster and a server-side dry-run both accept the version-plus-digest image configuration.