### PR TITLE
fix(clickstack): render Keeper digest reference

### DIFF
--- a/kubernetes/apps/clickstack/clickstack-app/app/helmrelease.yaml
+++ b/kubernetes/apps/clickstack/clickstack-app/app/helmrelease.yaml
@@ -118,11 +118,14 @@ spec:
         spec:
           # KeeperCluster supports the image through its container template.
           # Keep the currently running official 26.5.1.882 build, but make the
-          # version and digest explicit instead of tracking the mutable latest tag.
+          # content explicit instead of tracking the mutable latest tag. The
+          # current operator defaults an unset tag to latest before considering
+          # hash, so the complete immutable tag-and-digest suffix is supplied
+          # through tag and repository remains tag-free.
           containerTemplate:
             image:
-              repository: docker.io/clickhouse/clickhouse-keeper:26.5.1.882
-              hash: sha256:1264096f8c73a3e2fbc62cbbaa8cb83089edb4129c2d50f1b9e14c8fb1923cb3
+              repository: docker.io/clickhouse/clickhouse-keeper
+              tag: 26.5.1.882@sha256:1264096f8c73a3e2fbc62cbbaa8cb83089edb4129c2d50f1b9e14c8fb1923cb3
           dataVolumeClaimSpec:
             resources:
               requests:


### PR DESCRIPTION
## Summary

Correct the Keeper image pin after #360 exposed an operator defaulting behavior: a missing tag becomes `latest`, and the operator formats tag before hash.

## Changes

- Keep the repository tag-free.
- Supply the full `26.5.1.882@sha256:...` suffix through the supported tag field.
- Do not set `hash`; the deployed operator then renders the exact valid image reference.

## Reproduction / validation

```sh
yq -e '.' kubernetes/apps/clickstack/clickstack-app/app/helmrelease.yaml
kubectl kustomize kubernetes/apps/clickstack/clickstack-app/app
git diff --check
```

Live validation before publication confirmed the resulting StatefulSet and pod spec are `docker.io/clickhouse/clickhouse-keeper:26.5.1.882@sha256:1264096f8c73a3e2fbc62cbbaa8cb83089edb4129c2d50f1b9e14c8fb1923cb3`, Keeper is Ready, its original PVC remains Bound, and ClickHouse `SELECT 1` succeeds.