### PR TITLE
chore: sync Talos v1.13.6 source pin

### DIFF
--- a/talos/talenv.yaml
+++ b/talos/talenv.yaml
@@ -1,4 +1,4 @@
 # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
-talosVersion: v1.13.0
+talosVersion: v1.13.6
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
 kubernetesVersion: v1.36.0


### PR DESCRIPTION
## Summary

Synchronize the committed Talos source pin with the already-running v1.13.6 nodes.

## Changes

- Set `talosVersion` to `v1.13.6` in `talos/talenv.yaml`.

## Reproduction / validation

```sh
yq -r '.\ talos/talenv.yaml >/dev/null\nmise exec -- task talos:generate-config\ngit diff --check\n```\n\nNo Talos configuration was applied and no node was upgraded or rebooted.