### PR TITLE
fix: harden host agent images

### DIFF
--- a/containers/README.md
+++ b/containers/README.md
@@ -1,0 +1,36 @@
+# Host-agent image procedure
+
+Harbor is LAN-only (`192.168.1.106`), so build, digest lookup, and Trivy scan
+run in short-lived in-cluster Jobs; do not attempt them from the host. The
+builder is `gcr.io/kaniko-project/executor@sha256:c3109d5926a997b100c4343944e06c6b30a6804b2f9abe0994d3de6ef92b028e`.
+The scanner is `aquasec/trivy@sha256:6967db29ce5294d054121e94b3cb1262de858af63b4547bb1bade66a4306f2e4`.
+
+For each Dockerfile, create a ConfigMap named `host-agent-build-context` with
+`--from-file=Dockerfile=containers/<name>/Dockerfile`, then create a
+`registries` Job with `automountServiceAccountToken: false`, no host mounts,
+and an `emptyDir` mounted at `/docker`. Its `registry-auth` init container
+must use only `secretKeyRef` `harbor-admin-secret/HARBOR_ADMIN_PASSWORD` to
+write `/docker/config.json` for username `admin`. The non-privileged Kaniko
+container runs as UID 0 (required to unpack base-image ownership metadata),
+with `allowPrivilegeEscalation: false`, and mounts the ConfigMap file at
+`/workspace/Dockerfile`. It runs:
+
+```sh
+/kaniko/executor --context=dir:///workspace --dockerfile=/workspace/Dockerfile \
+  --destination=192.168.1.106/library/<name>:<version> --insecure --reproducible
+```
+
+Capture the pushed digest from Kaniko's non-secret `Pushed ...@sha256:` log,
+then use `:<tag>@sha256:<digest>` in the DaemonSet. Run the pinned Trivy image
+against that immutable reference and record normalized HIGH/CRITICAL counts.
+Use `busybox:1.37.0@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028`
+for the auth init container. Scan with `trivy image --quiet --insecure
+--scanners vuln --format json 192.168.1.106/library/<name>:<version>@sha256:<digest>`.
+Delete temporary resources with `kubectl -n registries delete job/<name>
+--wait=true` and `kubectl -n registries delete configmap/host-agent-build-context
+--wait=true`; the `emptyDir` docker config disappears with the Pod.
+
+Current 0.1.1 releases:
+
+- `storage-vxlan:0.1.1@sha256:4963bcf50365220415a02eece7a32c42466b7ead21e36e47028bf02cc7cbcd81`
+- `nvme-power-collector:0.1.1@sha256:a190eb1d473ce16a01100e3c9427b353b9ee864554a4ef6de1571ab4d0a35841`

--- a/containers/nvme-power-collector/Dockerfile
+++ b/containers/nvme-power-collector/Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
+
+RUN apk add --no-cache \
+    nvme-cli=2.16-r1 \
+    libcrypto3=3.5.7-r0 \
+    libssl3=3.5.7-r0

--- a/containers/storage-vxlan/Dockerfile
+++ b/containers/storage-vxlan/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
+
+RUN apk add --no-cache \
+    bash=5.3.3-r1 \
+    iproute2=6.17.0-r0 \
+    libcrypto3=3.5.7-r0 \
+    libssl3=3.5.7-r0

--- a/kubernetes/apps/network/storage-vxlan/app/daemonset.yaml
+++ b/kubernetes/apps/network/storage-vxlan/app/daemonset.yaml
@@ -33,8 +33,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: vxlan
-          # renovate: datasource=docker depName=nicolaka/netshoot
-          image: nicolaka/netshoot:v0.15@sha256:47b907d662d139d1e2f22bfe14f4efca1e3f1feed283572f47c970c780c03b61
+          image: 192.168.1.106/library/storage-vxlan:0.1.1@sha256:4963bcf50365220415a02eece7a32c42466b7ead21e36e47028bf02cc7cbcd81
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_NAME

--- a/kubernetes/apps/observability/nvme-power-collector/app/daemonset.yaml
+++ b/kubernetes/apps/observability/nvme-power-collector/app/daemonset.yaml
@@ -31,12 +31,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: collector
-          # Alpine + nvme-cli installed at startup. ~5s init penalty per pod
-          # (one apk add fetch), then a tight sleep loop. Avoids a custom
-          # image-build pipeline; if the apk fetch becomes flaky we can
-          # promote to a built image via the deploy-owned-app pipeline.
-          # renovate: datasource=docker depName=alpine
-          image: alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
+          image: 192.168.1.106/library/nvme-power-collector:0.1.1@sha256:a190eb1d473ce16a01100e3c9427b353b9ee864554a4ef6de1571ab4d0a35841
           imagePullPolicy: IfNotPresent
           securityContext:
             # Privileged required for /dev/nvme* ioctl (NVMe admin commands
@@ -45,6 +40,7 @@ spec:
             privileged: true
             runAsNonRoot: false
             runAsUser: 0
+            readOnlyRootFilesystem: true
           resources:
             requests:
               cpu: 5m
@@ -64,13 +60,6 @@ spec:
 
               echo "[nvme-power-collector] starting on $(hostname)"
 
-              # Install collection tools at runtime. Cached on subsequent restarts
-              # via the alpine package layer if the image is in spegel; cold cache
-              # adds ~5s. Failure here is fatal — without these tools the
-              # textfile would silently stay incomplete.
-              apk add --no-cache nvme-cli >/dev/null
-              echo "[nvme-power-collector] nvme-cli ready"
-
               # Atomic-write loop: each iteration writes a .tmp file then
               # renames it over .prom so node-exporter never reads a partial
               # file. 30 s cadence matches betty's scrape interval.
@@ -86,7 +75,7 @@ spec:
                   # after the colon, so awk $NF returns "value:0x..." not
                   # "0x...". Use sed with an anchored capture group to extract
                   # just the hex literal, then printf %d to convert to decimal.
-                  raw=$(nvme get-feature -f 0x02 "$d" 2>/dev/null | sed -n 's/.*Current value:[[:space:]]*0x\([0-9a-fA-F][0-9a-fA-F]*\).*/\1/p')
+                  raw=$(nvme get-feature "$d" -f 0x02 2>/dev/null | sed -n 's/.*Current value:[[:space:]]*0x\([0-9a-fA-F][0-9a-fA-F]*\).*/\1/p')
                   case "$raw" in
                     ''|*[!0-9a-fA-F]*) continue ;;
                   esac


### PR DESCRIPTION
## Summary

Replace runtime package installation and broad netshoot image with reproducible, immutable host-agent images.

## Validation

- YAML parse and Kustomize render
- In-cluster Trivy scans: zero HIGH/CRITICAL findings
- One-node NVMe non-privileged canary reached ioctl and received EPERM; privileged residual retained.