### PR TITLE
fix: allow Dragonfly operator to watch ConfigMaps

### DIFF
--- a/kubernetes/apps/databases/dragonfly-operator/app/upstream.yaml
+++ b/kubernetes/apps/databases/dragonfly-operator/app/upstream.yaml
@@ -7178,6 +7178,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
   - pods
   - services
   verbs:


### PR DESCRIPTION
## Summary

Add the ConfigMap permission required by Dragonfly operator v1.6.1. Without it, the controller repeatedly fails its cluster-wide ConfigMap informer with an RBAC denial.

## Changes

- Add `configmaps` to the existing core-resource manager ClusterRole rule.
- Match the upstream v1.6.1 RBAC manifest without unrelated vendored-manifest churn.

## Reproduction / validation

```sh
yq . kubernetes/apps/databases/dragonfly-operator/app/upstream.yaml
flux build ks dragonfly-operator -n databases --path ./kubernetes/apps/databases/dragonfly-operator/app --kustomization-file ./kubernetes/apps/databases/dragonfly-operator/ks.yaml --dry-run
kubectl kustomize kubernetes/apps/databases/dragonfly-operator/app | yq 'select(.kind == "ClusterRole" and .metadata.name == "dragonfly-operator-manager-role")'\n```