### PR TITLE
fix: align Multus daemon with v4.3 release

### DIFF
--- a/kubernetes/apps/network/multus/app/flux-kustomization.yaml
+++ b/kubernetes/apps/network/multus/app/flux-kustomization.yaml
@@ -32,7 +32,7 @@ spec:
         - op: replace
           path: /spec/template/spec/containers/0/image
           # renovate: datasource=docker depName=ghcr.io/k8snetworkplumbingwg/multus-cni
-          value: ghcr.io/k8snetworkplumbingwg/multus-cni:v4.2.4-thick@sha256:3c20900b5381fac7f9cbbdfac8370ea10a2f6ed7fbecc678384a9db57047abb1
+          value: ghcr.io/k8snetworkplumbingwg/multus-cni:v4.3.0-thick@sha256:2b9671447f3ea4e7e56730843dbf59445b9307246f393b61386b896d56ae51c9
     # Raise Multus cgroup memory limit 50Mi → 512Mi. Upstream default is
     # tuned for pod-creation rates that small clusters rarely see; anton
     # hits the limit during bursts because Multus invokes `cilium-cni` as


### PR DESCRIPTION
## Summary

Complete the Multus v4.3 upgrade by aligning the running daemon image with the v4.3 init-container binary installed by PR #328.

## Changes

- Update the main thick-plugin daemon image from v4.2.4 to the same pinned v4.3.0 digest already used by `install-multus-binary`.
- Preserve all Anton-specific Multus patches and network behavior.

## Reproduction / validation

```sh
yq . kubernetes/apps/network/multus/app/flux-kustomization.yaml
rg "multus-cni:v4.3.0-thick" kubernetes/apps/network/multus/app/flux-kustomization.yaml
kubectl apply --server-side --force-conflicts --dry-run=server --field-manager=kustomize-controller -f kubernetes/apps/network/multus/app/flux-kustomization.yaml
```