### PR TITLE
feat(harbor): enforce project image retention

### DIFF
--- a/kubernetes/apps/registries/harbor-config/app/kustomization.yaml
+++ b/kubernetes/apps/registries/harbor-config/app/kustomization.yaml
@@ -1,6 +1,12 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+configMapGenerator:
+  - name: harbor-retention-reconciler
+    files:
+      - reconcile.sh=./reconcile.sh
+    options:
+      disableNameSuffixHash: true
 resources:
   - ./postgres-cluster.yaml
   - ./dragonfly.yaml
@@ -9,3 +15,4 @@ resources:
   - ./externalsecret-s3.yaml
   - ./ingress-tailscale.yaml
   - ./prometheusrule.yaml
+  - ./retention-cronjob.yaml

--- a/kubernetes/apps/registries/harbor-config/app/reconcile.sh
+++ b/kubernetes/apps/registries/harbor-config/app/reconcile.sh
@@ -1,0 +1,134 @@
+#!/bin/sh
+
+set -eu
+
+: "${HARBOR_API_URL:?HARBOR_API_URL is required}"
+: "${HARBOR_USERNAME:?HARBOR_USERNAME is required}"
+: "${HARBOR_PASSWORD:?HARBOR_PASSWORD is required}"
+: "${HARBOR_RETENTION_CRON:?HARBOR_RETENTION_CRON is required}"
+: "${HARBOR_PROTECTED_TAGS:?HARBOR_PROTECTED_TAGS is required}"
+
+api_url="${HARBOR_API_URL%/}"
+auth="${HARBOR_USERNAME}:${HARBOR_PASSWORD}"
+
+harbor_request() {
+  method="$1"
+  path="$2"
+  payload="${3:-}"
+
+  if [ -n "$payload" ]; then
+    curl \
+      --fail \
+      --silent \
+      --show-error \
+      --retry 5 \
+      --retry-delay 5 \
+      --retry-connrefused \
+      --user "$auth" \
+      --request "$method" \
+      --header "Content-Type: application/json" \
+      --data "$payload" \
+      "$api_url$path"
+    return
+  fi
+
+  curl \
+    --fail \
+    --silent \
+    --show-error \
+    --retry 5 \
+    --retry-delay 5 \
+    --retry-connrefused \
+    --user "$auth" \
+    --request "$method" \
+    "$api_url$path"
+}
+
+policy_for_project() {
+  project_id="$1"
+
+  jq -n \
+    --argjson project_id "$project_id" \
+    --arg cron "$HARBOR_RETENTION_CRON" \
+    --arg protected_tags "$HARBOR_PROTECTED_TAGS" \
+    '
+      def all_repositories:
+        {repository: [{kind: "doublestar", decoration: "repoMatches", pattern: "**"}]};
+      def tagged_artifacts:
+        ({untagged: false} | tojson);
+      def selector($pattern):
+        {kind: "doublestar", decoration: "matches", pattern: $pattern, extras: tagged_artifacts};
+
+      {
+        algorithm: "or",
+        rules: [
+          {
+            disabled: false,
+            action: "retain",
+            scope_selectors: all_repositories,
+            tag_selectors: [selector("**")],
+            params: {latestPushedK: 3},
+            template: "latestPushedK"
+          },
+          {
+            disabled: false,
+            action: "retain",
+            scope_selectors: all_repositories,
+            tag_selectors: [selector($protected_tags)],
+            params: {},
+            template: "always"
+          }
+        ],
+        trigger: {
+          kind: "Schedule",
+          references: {},
+          settings: {cron: $cron}
+        },
+        scope: {level: "project", ref: $project_id}
+      }
+    '
+}
+
+normalise_policy() {
+  jq -S '
+    del(.id)
+    | del(.trigger.settings.next_scheduled_time)
+    | .rules |= map(del(.id, .priority))
+  '
+}
+
+reconcile_project() {
+  project_id="$1"
+  desired="$(policy_for_project "$project_id")"
+  retention_id="$(harbor_request GET "/projects/${project_id}/metadatas/" | jq -r '.retention_id // empty')"
+
+  if [ -z "$retention_id" ]; then
+    harbor_request POST /retentions "$desired" >/dev/null
+    echo "created retention policy for project ${project_id}"
+    return
+  fi
+
+  current="$(harbor_request GET "/retentions/${retention_id}")"
+  if [ "$(printf '%s' "$current" | normalise_policy)" = "$(printf '%s' "$desired" | normalise_policy)" ]; then
+    echo "retention policy for project ${project_id} is current"
+    return
+  fi
+
+  harbor_request PUT "/retentions/${retention_id}" "$desired" >/dev/null
+  echo "updated retention policy ${retention_id} for project ${project_id}"
+}
+
+page=1
+while :; do
+  projects="$(harbor_request GET "/projects?page=${page}&page_size=100")"
+  project_count="$(printf '%s' "$projects" | jq 'length')"
+
+  [ "$project_count" -eq 0 ] && break
+
+  printf '%s' "$projects" | jq -r '.[].project_id' | while IFS= read -r project_id; do
+    reconcile_project "$project_id"
+  done
+
+  [ "$project_count" -lt 100 ] && break
+  page=$((page + 1))
+done

--- a/kubernetes/apps/registries/harbor-config/app/retention-cronjob.yaml
+++ b/kubernetes/apps/registries/harbor-config/app/retention-cronjob.yaml
@@ -1,0 +1,81 @@
+# Reconcile Harbor's project-scoped retention policies from Git. Harbor does
+# not expose retention policies as a Kubernetes resource, so this bounded job
+# uses the supported Harbor API and the existing admin-password Secret.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: harbor-retention-reconcile
+  labels:
+    app.kubernetes.io/name: harbor-retention
+    app.kubernetes.io/part-of: harbor
+spec:
+  schedule: "17 1 * * *"
+  startingDeadlineSeconds: 900
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 900
+      backoffLimit: 3
+      ttlSecondsAfterFinished: 86400
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: harbor-retention
+            app.kubernetes.io/part-of: harbor
+        spec:
+          restartPolicy: OnFailure
+          automountServiceAccountToken: false
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: reconcile
+              # Existing Anton convention; this image includes curl and jq.
+              image: alpine/k8s:1.36.2@sha256:44ef4942e171939b9c665a4a84beb80e2dcdb9a24330d4651cfdfd2e9deecc47
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/sh
+              args:
+                - /opt/reconcile.sh
+              env:
+                - name: HARBOR_API_URL
+                  value: http://harbor-core/api/v2.0
+                - name: HARBOR_USERNAME
+                  value: admin
+                - name: HARBOR_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: harbor-admin-secret
+                      key: HARBOR_ADMIN_PASSWORD
+                # Harbor's scheduler uses a six-field cron expression with
+                # seconds. Run policy execution daily at 01:30 UTC.
+                - name: HARBOR_RETENTION_CRON
+                  value: "0 30 1 * * *"
+                - name: HARBOR_PROTECTED_TAGS
+                  value: "{latest,stable,prod,release-*}"
+              volumeMounts:
+                - name: reconciler
+                  mountPath: /opt/reconcile.sh
+                  subPath: reconcile.sh
+                  readOnly: true
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 100m
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: [ALL]
+          volumes:
+            - name: reconciler
+              configMap:
+                name: harbor-retention-reconciler


### PR DESCRIPTION
## Summary
- reconcile Harbor retention policies for every project from Git
- retain newest 3 tagged artifacts per repository
- preserve latest, stable, prod, and release-* tags
- run Harbor retention daily at 01:30 UTC

## Validation
- sh -n reconcile.sh
- kubectl kustomize harbor-config/app
- kubectl apply --dry-run=client --validate=false on rendered manifests
- focused Flux source checks

After merge, verify the reconciler Job and Harbor artifact counts before running garbage collection.