### PR TITLE
fix(harbor): escape reconciler variables for Flux

### DIFF
--- a/kubernetes/apps/registries/harbor-config/app/reconcile.sh
+++ b/kubernetes/apps/registries/harbor-config/app/reconcile.sh
@@ -2,21 +2,21 @@
 
 set -eu
 
-: "${HARBOR_API_URL:?HARBOR_API_URL is required}"
-: "${HARBOR_USERNAME:?HARBOR_USERNAME is required}"
-: "${HARBOR_PASSWORD:?HARBOR_PASSWORD is required}"
-: "${HARBOR_RETENTION_CRON:?HARBOR_RETENTION_CRON is required}"
-: "${HARBOR_PROTECTED_TAGS:?HARBOR_PROTECTED_TAGS is required}"
+: "$${HARBOR_API_URL:?HARBOR_API_URL is required}"
+: "$${HARBOR_USERNAME:?HARBOR_USERNAME is required}"
+: "$${HARBOR_PASSWORD:?HARBOR_PASSWORD is required}"
+: "$${HARBOR_RETENTION_CRON:?HARBOR_RETENTION_CRON is required}"
+: "$${HARBOR_PROTECTED_TAGS:?HARBOR_PROTECTED_TAGS is required}"
 
-api_url="${HARBOR_API_URL%/}"
-auth="${HARBOR_USERNAME}:${HARBOR_PASSWORD}"
+api_url="$${HARBOR_API_URL%/}"
+auth="$${HARBOR_USERNAME}:$${HARBOR_PASSWORD}"
 
 harbor_request() {
-  method="$1"
-  path="$2"
-  payload="${3:-}"
+  method="$${1}"
+  path="$${2}"
+  payload="$${3:-}"
 
-  if [ -n "$payload" ]; then
+  if [ -n "$${payload}" ]; then
     curl \
       --fail \
       --silent \
@@ -24,11 +24,11 @@ harbor_request() {
       --retry 5 \
       --retry-delay 5 \
       --retry-connrefused \
-      --user "$auth" \
-      --request "$method" \
+      --user "$${auth}" \
+      --request "$${method}" \
       --header "Content-Type: application/json" \
-      --data "$payload" \
-      "$api_url$path"
+      --data "$${payload}" \
+      "$${api_url}$${path}"
     return
   fi
 
@@ -39,25 +39,25 @@ harbor_request() {
     --retry 5 \
     --retry-delay 5 \
     --retry-connrefused \
-    --user "$auth" \
-    --request "$method" \
-    "$api_url$path"
+    --user "$${auth}" \
+    --request "$${method}" \
+    "$${api_url}$${path}"
 }
 
 policy_for_project() {
-  project_id="$1"
+  project_id="$${1}"
 
   jq -n \
-    --argjson project_id "$project_id" \
-    --arg cron "$HARBOR_RETENTION_CRON" \
-    --arg protected_tags "$HARBOR_PROTECTED_TAGS" \
+    --argjson project_id "$${project_id}" \
+    --arg cron "$${HARBOR_RETENTION_CRON}" \
+    --arg protected_tags "$${HARBOR_PROTECTED_TAGS}" \
     '
       def all_repositories:
         {repository: [{kind: "doublestar", decoration: "repoMatches", pattern: "**"}]};
       def tagged_artifacts:
         ({untagged: false} | tojson);
-      def selector($pattern):
-        {kind: "doublestar", decoration: "matches", pattern: $pattern, extras: tagged_artifacts};
+      def selector($$pattern):
+        {kind: "doublestar", decoration: "matches", pattern: $$pattern, extras: tagged_artifacts};
 
       {
         algorithm: "or",
@@ -74,7 +74,7 @@ policy_for_project() {
             disabled: false,
             action: "retain",
             scope_selectors: all_repositories,
-            tag_selectors: [selector($protected_tags)],
+            tag_selectors: [selector($$protected_tags)],
             params: {},
             template: "always"
           }
@@ -82,9 +82,9 @@ policy_for_project() {
         trigger: {
           kind: "Schedule",
           references: {},
-          settings: {cron: $cron}
+          settings: {cron: $$cron}
         },
-        scope: {level: "project", ref: $project_id}
+        scope: {level: "project", ref: $$project_id}
       }
     '
 }
@@ -98,37 +98,37 @@ normalise_policy() {
 }
 
 reconcile_project() {
-  project_id="$1"
-  desired="$(policy_for_project "$project_id")"
-  retention_id="$(harbor_request GET "/projects/${project_id}/metadatas/" | jq -r '.retention_id // empty')"
+  project_id="$${1}"
+  desired="$$(policy_for_project "$${project_id}")"
+  retention_id="$$(harbor_request GET "/projects/$${project_id}/metadatas/" | jq -r '.retention_id // empty')"
 
-  if [ -z "$retention_id" ]; then
-    harbor_request POST /retentions "$desired" >/dev/null
-    echo "created retention policy for project ${project_id}"
+  if [ -z "$${retention_id}" ]; then
+    harbor_request POST /retentions "$${desired}" >/dev/null
+    echo "created retention policy for project $${project_id}"
     return
   fi
 
-  current="$(harbor_request GET "/retentions/${retention_id}")"
-  if [ "$(printf '%s' "$current" | normalise_policy)" = "$(printf '%s' "$desired" | normalise_policy)" ]; then
-    echo "retention policy for project ${project_id} is current"
+  current="$$(harbor_request GET "/retentions/$${retention_id}")"
+  if [ "$$(printf '%s' "$${current}" | normalise_policy)" = "$$(printf '%s' "$${desired}" | normalise_policy)" ]; then
+    echo "retention policy for project $${project_id} is current"
     return
   fi
 
-  harbor_request PUT "/retentions/${retention_id}" "$desired" >/dev/null
-  echo "updated retention policy ${retention_id} for project ${project_id}"
+  harbor_request PUT "/retentions/$${retention_id}" "$${desired}" >/dev/null
+  echo "updated retention policy $${retention_id} for project $${project_id}"
 }
 
 page=1
 while :; do
-  projects="$(harbor_request GET "/projects?page=${page}&page_size=100")"
-  project_count="$(printf '%s' "$projects" | jq 'length')"
+  projects="$$(harbor_request GET "/projects?page=$${page}&page_size=100")"
+  project_count="$$(printf '%s' "$${projects}" | jq 'length')"
 
-  [ "$project_count" -eq 0 ] && break
+  [ "$${project_count}" -eq 0 ] && break
 
-  printf '%s' "$projects" | jq -r '.[].project_id' | while IFS= read -r project_id; do
-    reconcile_project "$project_id"
+  printf '%s' "$${projects}" | jq -r '.[].project_id' | while IFS= read -r project_id; do
+    reconcile_project "$${project_id}"
   done
 
-  [ "$project_count" -lt 100 ] && break
+  [ "$${project_count}" -lt 100 ] && break
   page=$((page + 1))
 done


### PR DESCRIPTION
Flux post-build substitution runs in strict mode for harbor-config. Escape shell and jq dollar references in the reconciler ConfigMap so Flux preserves them for the container.

Validation: source and post-substitution shell syntax, Kustomize render, Kubernetes client dry-run.